### PR TITLE
Chatのリファクタリング（ローディング処理、参加者リストの仕様変更、日本語改行バグ）

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,7 +4,6 @@ import { AppModule } from './app.module';
 import { PrismaService } from './prisma/prisma.service';
 import * as bodyParser from 'body-parser';
 import * as cookieParser from 'cookie-parser';
-import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -17,7 +17,6 @@ async function bootstrap() {
   const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('swagger', app, swaggerDocument);
 
-  app.useGlobalPipes(new ValidationPipe());
   app.enableCors({
     credentials: true,
     origin: ['http://localhost:3000'], //許可したいfrontsideのURL

--- a/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
+++ b/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
@@ -45,6 +45,7 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
 
   useEffect(() => {
     try {
+      setLoading(true);
       getUserDM().then((data) => {
         setDMRooms([]);
         data.map((room => setDMRooms((prev: any) => [...prev, { id: room.id, name: getFriendNameFromRoomName(room.name) }]))
@@ -55,7 +56,7 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
     } finally {
       setTimeout(() => {
         setLoading(false);
-      }, 500);
+      }, 300);
     }
   }, [userName])
 

--- a/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
+++ b/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Grid, Typography } from "@mui/material";
+import { Avatar, Box, CircularProgress, Grid, Typography } from "@mui/material";
 import PersonIcon from '@mui/icons-material/Person';
 import { Link, useLocation } from "react-router-dom";
 import React, { useEffect, useState } from "react";
@@ -24,6 +24,7 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
   const { socket, setDMRooms, DMRooms, isLeave, userName } = props;
   const roomID = useLocation().pathname.split('/')[3];
   const [prevRoomId, setPrevRoomId] = useState<string>();
+  const [Loading, setLoading] = useState(true);
 
   const getFriendNameFromRoomName = (room: string): string => {
     let friendName: string = '';
@@ -43,11 +44,19 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
   };
 
   useEffect(() => {
-    getUserDM().then((data) => {
-      setDMRooms([]);
-      data.map((room => setDMRooms((prev: any) => [...prev, { id: room.id, name: getFriendNameFromRoomName(room.name) }]))
-      )
-    })
+    try {
+      getUserDM().then((data) => {
+        setDMRooms([]);
+        data.map((room => setDMRooms((prev: any) => [...prev, { id: room.id, name: getFriendNameFromRoomName(room.name) }]))
+        )
+      })
+    } catch (error) {
+      alert('DM取得に失敗しました。ブラウザをリフレッシュしてください');
+    } finally {
+      setTimeout(() => {
+        setLoading(false);
+      }, 500);
+    }
   }, [userName])
 
 
@@ -61,6 +70,16 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
 
   const handleClick = (roomId: string) => {
     socket.emit('join_chat_room', { id: roomId })
+  }
+
+  if (Loading) {
+    return (
+      <>
+        <Box height={'3rem'} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress/>
+        </Box>
+      </>
+    )
   }
 
   return (

--- a/frontend/src/components/chat/group/ChannelCreateDialog.tsx
+++ b/frontend/src/components/chat/group/ChannelCreateDialog.tsx
@@ -15,7 +15,7 @@ type ChannelCreateDialogProps = {
 type CreateChannelDto = {
   name: string;
   type: string;
-  password?: string;
+  password: string;
 }
 
 /**
@@ -33,8 +33,12 @@ export default function ChannelCreateDialog(props: ChannelCreateDialogProps) {
   })
 
   const onSubmit: SubmitHandler<CreateChannelDto> = async (data) => {
-    const res = await axios.post(`http://localhost:8080/chat/room`, { type: data.type, name: data.name, password: data.password })
-    setChannels((prev: any) => [...prev, { name: data.name, id: res.data.id }])
+    try {
+      const res = await axios.post(`http://localhost:8080/chat/room`, { type: data.type, name: data.name, password: data.password })
+      setChannels((prev: any) => [...prev, { name: data.name, id: res.data.id }])
+    } catch (error: any) {
+      alert(error.response.data.message);
+    }
     reset();
     handleClose();
   }

--- a/frontend/src/components/chat/group/ChannelListComponent.tsx
+++ b/frontend/src/components/chat/group/ChannelListComponent.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Grid, Typography } from "@mui/material";
+import { Avatar, Box, CircularProgress, Grid, Typography } from "@mui/material";
 import PersonIcon from '@mui/icons-material/Person';
 import axios from "axios";
 import React, { useEffect, useState } from "react";
@@ -22,6 +22,7 @@ export default function ChannelListComponent(props: ChannelListComponentProps) {
   const { socket, channels, setChannels, isLeave } = props;
   const roomID = useLocation().pathname.split('/')[3];
   const [prevRoomId, setPrevRoomId] = useState<string>();
+  const [Loading, setLoading] = useState(true);
 
   const getChannels = async (): Promise<ChatRoom[]> => {
     const res = await axios.get(`http://localhost:8080/chat/channel`);
@@ -36,9 +37,26 @@ export default function ChannelListComponent(props: ChannelListComponentProps) {
   }, [roomID, socket]);
 
   useEffect(() => {
-    getChannels().then((data) => { setChannels(data); })
+    try {
+      getChannels().then((data) => { setChannels(data); })
+    } catch (error) {
+      alert('チャンネル取得に失敗しました。ブラウザをリフレッシュしてください');
+    } finally {
+      setTimeout(() => {
+        setLoading(false);
+      }, 500);
+    }
   }, [])
 
+  if (Loading) {
+    return (
+      <>
+        <Box height={'3rem'} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress/>
+        </Box>
+      </>
+    )
+  }
 
   return (
     <>

--- a/frontend/src/components/chat/group/ChannelListComponent.tsx
+++ b/frontend/src/components/chat/group/ChannelListComponent.tsx
@@ -38,13 +38,14 @@ export default function ChannelListComponent(props: ChannelListComponentProps) {
 
   useEffect(() => {
     try {
+      setLoading(true);
       getChannels().then((data) => { setChannels(data); })
     } catch (error) {
       alert('チャンネル取得に失敗しました。ブラウザをリフレッシュしてください');
     } finally {
       setTimeout(() => {
         setLoading(false);
-      }, 500);
+      }, 300);
     }
   }, [])
 

--- a/frontend/src/components/chat/utils/ChatlogComponent.tsx
+++ b/frontend/src/components/chat/utils/ChatlogComponent.tsx
@@ -90,7 +90,7 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                   >
                     <Box
                       maxWidth={'95%'}
-                      textAlign={'center'}
+                      textAlign={'left'}
                     >
                       {chat.text}
                     </Box>
@@ -133,7 +133,6 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                 >
                   <Box
                     maxWidth={'95%'}
-                    textAlign={'center'}
                   >
                     {chat.text}
                   </Box>

--- a/frontend/src/components/chat/utils/ChatlogComponent.tsx
+++ b/frontend/src/components/chat/utils/ChatlogComponent.tsx
@@ -54,17 +54,17 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
   return (
     <Box
       width={'95%'}
+      height={'100%'}
       sx={{ color: '#3C444B', overflow: 'auto'}}
     >
       {chatLog.map((chat, idx) => (
         userId === chat.senderUserId ? (
           <Box
-          key={idx}
-          mb={2}
-          width={'100%'}
-          height={'5rem'}
-          sx={{ display: 'flex', alignItems: 'center'}}
-        >
+            key={idx}
+            mb={2}
+            width={'100%'}
+            sx={{ display: 'flex', alignItems: 'center'}}
+          >
           <Grid
             container
             alignItems={'end'}
@@ -72,16 +72,16 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
           >
               <Grid
                 item
+                xs
               >
                 <Typography variant="caption" >You {chat.time}</Typography>
                 <Box
-                  sx={{ display: 'flex', justifyContent: 'end', wordBreak: 'break-word'}}
+                  sx={{ display: 'flex', justifyContent: 'end'}}
                   mr={2}
                 >
                   <Box
-                    maxWidth={'30rem'}
-                    width={ chat.text.length * 0.7 > 8 ? `calc(0.6rem * ${chat.text.length})` : `calc(1.1rem * ${chat.text.length})`}
-                    minHeight={'3rem'}
+                    mb={1}
+                    padding={'1rem'}
                     justifyContent='center'
                     sx={{
                       backgroundColor: '#d0d3e4', color: '#3C444B', display: 'flex', alignItems: 'center',
@@ -89,7 +89,7 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                     }}
                   >
                     <Box
-                      width={'80%'}
+                      maxWidth={'95%'}
                       textAlign={'center'}
                     >
                       {chat.text}
@@ -97,7 +97,7 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                   </Box>
                 </Box>
             </Grid>
-            <Grid item mr={2}>
+            <Grid item xs={0.5}>
               <Avatar><PersonIcon/></Avatar>
             </Grid>
           </Grid>
@@ -106,8 +106,8 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
           <Box
           key={idx}
           mb={2}
-          width={'100%'}
-          height={'5rem'}
+          width={'95%'}
+          height={'100%'}
           sx={{ display: 'flex', alignItems: 'center' }}
         >
           <Grid
@@ -120,20 +120,19 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
             <Grid item>
               <Typography variant="caption" >{chat.senderName}  {chat.time}</Typography>
               <Box
-                  sx={{ display: 'flex', wordBreak: 'break-word'}}
+                  sx={{ display: 'flex'}}
                   mr={2}
                 >
                 <Box
-                  width={ chat.text.length * 0.7 > 8 ? `calc(0.6rem * ${chat.text.length})` : `calc(1.1rem * ${chat.text.length})`}
-                  minHeight={'3rem'}
-                  justifyContent='center'
+                  mb={1}
+                  padding={'1rem'}
                   sx={{
                     backgroundColor: '#ffffff', color: '#3C444B', display: 'flex', alignItems: 'center',
                     borderRadius: '20px 20px 20px 0px',
                   }}
                 >
                   <Box
-                    width={'80%'}
+                    maxWidth={'95%'}
                     textAlign={'center'}
                   >
                     {chat.text}

--- a/frontend/src/components/chat/utils/ChatlogComponent.tsx
+++ b/frontend/src/components/chat/utils/ChatlogComponent.tsx
@@ -87,7 +87,6 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
           <Grid
             container
             alignItems={'end'}
-            justifyContent={'flex-end'}
           >
               <Grid
                 item
@@ -97,7 +96,7 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                   sx={{ display: 'flex', justifyContent: 'end'}}
                   mr={2}
                 >
-                  <Box>
+                  <Box textAlign={'left'}>
                     <Typography variant="caption" >You {chat.time}</Typography>
                     <Box
                       padding={'1rem'}
@@ -115,7 +114,7 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                   </Box>
                 </Box>
             </Grid>
-            <Grid item xs={0.5}>
+            <Grid item>
               <Avatar><PersonIcon/></Avatar>
             </Grid>
           </Grid>
@@ -130,9 +129,8 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
           <Grid
             container
             alignItems={'end'}
-            justifyContent={'flex-end'}
           >
-            <Grid item xs={0.5}>
+            <Grid item>
               <Avatar><PersonIcon/></Avatar>
             </Grid>
             <Grid item xs>

--- a/frontend/src/components/chat/utils/ChatlogComponent.tsx
+++ b/frontend/src/components/chat/utils/ChatlogComponent.tsx
@@ -100,17 +100,14 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                   <Box>
                     <Typography variant="caption" >You {chat.time}</Typography>
                     <Box
-                      mb={1}
                       padding={'1rem'}
-                      justifyContent='center'
                       sx={{
-                        backgroundColor: '#d0d3e4', color: '#3C444B', display: 'flex', alignItems: 'center',
-                        borderRadius: '20px 20px 0px 20px',
+                        backgroundColor: '#d0d3e4', color: '#3C444B', display: 'flex',
+                        alignItems: 'center', justifyContent: 'center', borderRadius: '20px 20px 0px 20px',
                       }}
                     >
                       <Box
-                        maxWidth={'95%'}
-                        textAlign={'center'}
+                        textAlign={'left'}
                       >
                         {chat.text}
                       </Box>
@@ -133,26 +130,27 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
           <Grid
             container
             alignItems={'end'}
+            justifyContent={'flex-end'}
           >
-                <Grid item mr={2} xs={0.5}>
+            <Grid item xs={0.5}>
               <Avatar><PersonIcon/></Avatar>
             </Grid>
             <Grid item xs>
               <Box
-                sx={{ display: 'flex'}}
+                sx={{ display: 'flex', justifyContent: 'start'}}
+                ml={2}
                >
-                <Box>
+                <Box textAlign={'right'}>
                   <Typography variant="caption" >{chat.senderName}  {chat.time}</Typography>
                   <Box
-                    mb={1}
                     padding={'1rem'}
                     sx={{
-                      backgroundColor: '#ffffff', color: '#3C444B', display: 'flex', alignItems: 'center',
-                      borderRadius: '20px 20px 20px 0px',
+                      backgroundColor: '#ffffff', color: '#3C444B', display: 'flex',
+                      alignItems: 'center', justifyContent: 'center', borderRadius: '20px 20px 20px 0px',
                     }}
                   >
                     <Box
-                      maxWidth={'95%'}
+                      textAlign={'left'}
                     >
                       {chat.text}
                     </Box>

--- a/frontend/src/components/chat/utils/ChatlogComponent.tsx
+++ b/frontend/src/components/chat/utils/ChatlogComponent.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Grid, Typography } from "@mui/material";
+import { Avatar, Box, CircularProgress, Grid, Typography } from "@mui/material";
 import PersonIcon from '@mui/icons-material/Person';
 import axios from "axios";
 import React, { createRef, useEffect, useLayoutEffect, useState } from "react";
@@ -24,6 +24,7 @@ type ChatlogComponentProps = {
 export default function ChatlogComponent(props: ChatlogComponentProps) {
   const { roomId, socket, userId } = props;
   const [chatLog, setChatLog] = useState<ChatLog>([]);
+  const [Loading, setLoading] = useState(true);
   const latestChatRef = createRef<HTMLDivElement>();
 
   useEffect(() => {
@@ -36,7 +37,7 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
     latestChatRef.current?.scrollIntoView();
   }, [chatLog, latestChatRef])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const fetchChat = async () => {
       setChatLog([]);
       const { data } = await axios.get<Message[]>(`http://localhost:8080/chat/room/log/${roomId}`);
@@ -48,8 +49,26 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
       }
     }
 
-    fetchChat();
+    try {
+      fetchChat();
+    } catch (error) {
+      alert('チャットを正しくロードできませんでした。ブラウザをリフレッシュしてください');
+    } finally {
+      setTimeout(() => {
+        setLoading(false);
+      }, 300);
+    }
   }, [roomId])
+
+  if (Loading) {
+    return (
+      <>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress />
+        </Box>
+      </>
+    )
+  }
 
   return (
     <Box
@@ -108,35 +127,35 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
           <Box
           key={idx}
           mb={2}
-          width={'95%'}
-          height={'100%'}
+          width={'100%'}
           sx={{ display: 'flex', alignItems: 'center' }}
         >
           <Grid
             container
             alignItems={'end'}
           >
-            <Grid item mr={2}>
+                <Grid item mr={2} xs={0.5}>
               <Avatar><PersonIcon/></Avatar>
             </Grid>
-            <Grid item>
-              <Typography variant="caption" >{chat.senderName}  {chat.time}</Typography>
+            <Grid item xs>
               <Box
-                  sx={{ display: 'flex'}}
-                  mr={2}
-                >
-                <Box
-                  mb={1}
-                  padding={'1rem'}
-                  sx={{
-                    backgroundColor: '#ffffff', color: '#3C444B', display: 'flex', alignItems: 'center',
-                    borderRadius: '20px 20px 20px 0px',
-                  }}
-                >
+                sx={{ display: 'flex'}}
+               >
+                <Box>
+                  <Typography variant="caption" >{chat.senderName}  {chat.time}</Typography>
                   <Box
-                    maxWidth={'95%'}
+                    mb={1}
+                    padding={'1rem'}
+                    sx={{
+                      backgroundColor: '#ffffff', color: '#3C444B', display: 'flex', alignItems: 'center',
+                      borderRadius: '20px 20px 20px 0px',
+                    }}
                   >
-                    {chat.text}
+                    <Box
+                      maxWidth={'95%'}
+                    >
+                      {chat.text}
+                    </Box>
                   </Box>
                 </Box>
               </Box>

--- a/frontend/src/components/chat/utils/ChatlogComponent.tsx
+++ b/frontend/src/components/chat/utils/ChatlogComponent.tsx
@@ -74,25 +74,27 @@ export default function ChatlogComponent(props: ChatlogComponentProps) {
                 item
                 xs
               >
-                <Typography variant="caption" >You {chat.time}</Typography>
                 <Box
                   sx={{ display: 'flex', justifyContent: 'end'}}
                   mr={2}
                 >
-                  <Box
-                    mb={1}
-                    padding={'1rem'}
-                    justifyContent='center'
-                    sx={{
-                      backgroundColor: '#d0d3e4', color: '#3C444B', display: 'flex', alignItems: 'center',
-                      borderRadius: '20px 20px 0px 20px',
-                    }}
-                  >
+                  <Box>
+                    <Typography variant="caption" >You {chat.time}</Typography>
                     <Box
-                      maxWidth={'95%'}
-                      textAlign={'left'}
+                      mb={1}
+                      padding={'1rem'}
+                      justifyContent='center'
+                      sx={{
+                        backgroundColor: '#d0d3e4', color: '#3C444B', display: 'flex', alignItems: 'center',
+                        borderRadius: '20px 20px 0px 20px',
+                      }}
                     >
-                      {chat.text}
+                      <Box
+                        maxWidth={'95%'}
+                        textAlign={'center'}
+                      >
+                        {chat.text}
+                      </Box>
                     </Box>
                   </Box>
                 </Box>

--- a/frontend/src/components/chat/utils/UserParticipantsList.tsx
+++ b/frontend/src/components/chat/utils/UserParticipantsList.tsx
@@ -1,6 +1,7 @@
 import { Avatar, Box, Grid, Typography } from "@mui/material";
 import PersonIcon from '@mui/icons-material/Person';
 import axios from "axios";
+import { Link } from "react-router-dom";
 import React, {useEffect, useState } from "react";
 import InvitationButton from "../group/InvitationButton";
 import AdminButton from "./AdminButton";
@@ -76,11 +77,15 @@ export default function UserParticipantList(props: UserParticipantListProps) {
             <Box>
               <Grid container sx={{ display: 'flex', alignItems: 'center' }}>
                 <Grid item mr={2}>
+                  <Link to={'/user'}>
                   <Avatar ><PersonIcon /></Avatar>
+                  </Link>
                 </Grid>
                 <Grid item>
                   <Typography variant="subtitle1">
-                    {member.name}
+                    <Link to={'/user'} className={'UserParticipantLink'}>
+                      {member.name}
+                    </Link>
                   </Typography>
                   {member.userId === userId ?
                     (

--- a/frontend/src/components/chat/utils/UserParticipantsList.tsx
+++ b/frontend/src/components/chat/utils/UserParticipantsList.tsx
@@ -92,13 +92,13 @@ export default function UserParticipantList(props: UserParticipantListProps) {
             <Box>
               <Grid container sx={{ display: 'flex', alignItems: 'center' }}>
                 <Grid item mr={2}>
-                  <Link to={'/user'}>
+                  <Link to={`/user/${member.userId}`}>
                   <Avatar ><PersonIcon /></Avatar>
                   </Link>
                 </Grid>
                 <Grid item>
                   <Typography variant="subtitle1">
-                    <Link to={'/user'} className={'UserParticipantLink'}>
+                    <Link to={`/user/${member.userId}`} className={'UserParticipantLink'}>
                       {member.name}
                     </Link>
                   </Typography>

--- a/frontend/src/components/chat/utils/UserParticipantsList.tsx
+++ b/frontend/src/components/chat/utils/UserParticipantsList.tsx
@@ -60,7 +60,7 @@ export default function UserParticipantList(props: UserParticipantListProps) {
       } finally {
         setTimeout(() => {
           setLoading(false);
-        }, 800);
+        }, 500);
       }
     }
 

--- a/frontend/src/components/chat/utils/UserParticipantsList.tsx
+++ b/frontend/src/components/chat/utils/UserParticipantsList.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Grid, Typography } from "@mui/material";
+import { Avatar, Box, CircularProgress, Grid, Typography } from "@mui/material";
 import PersonIcon from '@mui/icons-material/Person';
 import axios from "axios";
 import { Link } from "react-router-dom";
@@ -24,6 +24,7 @@ export default function UserParticipantList(props: UserParticipantListProps) {
   const [userId, setUserId] = useState<string>();
   const [myRole, setMyRole] = useState<string>('');
   const [members, setMembers] = useState<MemberPayload[]>([]);
+  const [Loading, setLoading] = useState(true);
 
   useEffect(() => {
     const getUserId = async () => {
@@ -55,13 +56,26 @@ export default function UserParticipantList(props: UserParticipantListProps) {
           }
         }
       } catch (error) {
-        loadMember();
+        alert('メンバーが正しく取得できませんでした。ブラウザをリフレッシュしてください');
+      } finally {
+        setTimeout(() => {
+          setLoading(false);
+        }, 800);
       }
     }
 
     loadMember();
   }, [roomId, userId]);
 
+  if (Loading) {
+    return (
+      <>
+        <Box height={'5rem'} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress/>
+        </Box>
+      </>
+    )
+  }
 
   return (
     <>

--- a/frontend/src/components/chat/utils/UserParticipantsList.tsx
+++ b/frontend/src/components/chat/utils/UserParticipantsList.tsx
@@ -40,6 +40,7 @@ export default function UserParticipantList(props: UserParticipantListProps) {
   useEffect(() => {
     const loadMember = async () => {
       try {
+        setLoading(true);
         const { data } = await axios.get(`http://localhost:8080/chat/room/${roomId}`);
         if (data.members) {
           const newMembers: MemberPayload[] = data.members.map((member: any) => ({
@@ -60,7 +61,7 @@ export default function UserParticipantList(props: UserParticipantListProps) {
       } finally {
         setTimeout(() => {
           setLoading(false);
-        }, 500);
+        }, 300);
       }
     }
 

--- a/frontend/src/styles/Chat.css
+++ b/frontend/src/styles/Chat.css
@@ -35,3 +35,8 @@ input[type=text]::placeholder {
   background-color: #f7f8fa;
   border-radius: 5%;
 }
+
+.UserParticipantLink {
+  text-decoration: none;
+  color: #3C444B;
+}

--- a/frontend/src/utils/PrivateRouter.tsx
+++ b/frontend/src/utils/PrivateRouter.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from "@mui/material";
+import { Box, CircularProgress } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import userAuth from "./userAuth";
@@ -18,7 +18,7 @@ export default function PrivateRouter({ children }: { children: JSX.Element }) {
       } finally {
         setTimeout(() => {
           setLoading(false);
-        }, 500);
+        }, 1000);
       }
     };
 
@@ -26,7 +26,13 @@ export default function PrivateRouter({ children }: { children: JSX.Element }) {
   }, []);
 
   if (loading) {
-    return <CircularProgress />;
+    return (
+      <Box height={'100vh'} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Box height={'10vh'} width={'10vw'}>
+          <CircularProgress/>
+        </Box>
+      </Box>
+    );
   }
 
   if (!auth) {


### PR DESCRIPTION
## やったこと
- 無駄レンダリングを防ぐためにtry, catch, finallyでローディング画面を追加
- 参加者リストからプロフィール画面に遷移できる仕様に変更
- チャットログの日本語表示のバグを解消

## 次回アクション
- #213 

## 動作確認
```
ユーザを作成してチャットを行う
参加者リストからプロフィールに遷移できるか確認
```

## issues

about : #193, #190, #184

close #193, #190, #184
