### PR TITLE
【Chat】プロフィール画像を参加者リスト、DMなどで表示できるように変更

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -244,7 +244,7 @@ export class AuthService {
       .get(imageUrl, { responseType: 'arraybuffer' })
       .pipe(map((res) => Buffer.from(res.data, 'binary').toString('base64')));
     const base64 = await lastValueFrom(response$);
-    return base64;
+    return 'data:image/jpeg;base64,' + base64;
   }
 
   async calcImageSize(base64: string): Promise<number> {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -223,6 +223,13 @@ export class ChatService {
           },
         },
       },
+      include: {
+        members: {
+          include: {
+            user: true,
+          },
+        },
+      },
     });
     return channels;
   }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -143,7 +143,13 @@ export class ChatService {
           },
         },
       },
-      include: { members: true },
+      include: {
+        members: {
+          include: {
+            user: true,
+          },
+        },
+      },
     });
 
     return DirectMessageRooms;

--- a/frontend/src/components/auth/SignupComponent.tsx
+++ b/frontend/src/components/auth/SignupComponent.tsx
@@ -50,8 +50,7 @@ function SignupComponent() {
     if (!file) return;
     const reader = new FileReader();
     reader.onload = () => {
-      const result = reader.result as string;
-      const base64 = result.replace(/^data:image\/(png|jpg|jpeg);base64,/, '');
+      const base64 = reader.result as string;
       setImage(base64);
     }
     reader.readAsDataURL(file);

--- a/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
+++ b/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
@@ -1,5 +1,4 @@
 import { Avatar, Box, CircularProgress, Grid, Typography } from "@mui/material";
-import PersonIcon from '@mui/icons-material/Person';
 import { Link, useLocation } from "react-router-dom";
 import React, { useEffect, useState } from "react";
 import { Socket } from "socket.io-client";
@@ -123,7 +122,7 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
             className={'FriendList'}
             >
               <Grid item mr={2} ml={3}>
-                <Avatar ><PersonIcon /></Avatar>
+                <Avatar src={`${room.image}`} />
               </Grid>
               <Grid item>
               <Typography variant="subtitle1">

--- a/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
+++ b/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
@@ -65,7 +65,7 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
     } finally {
       setTimeout(() => {
         setLoading(false);
-      }, 300);
+      }, 500);
     }
   }, [userName])
 

--- a/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
+++ b/frontend/src/components/chat/dm/ChatFriendsComponent.tsx
@@ -38,19 +38,28 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
     return friendName;
   }
 
-  const getUserDM = async (): Promise<ChatRoom[]> => {
-    const res = await axios.get(`http://localhost:8080/chat/dm`);
-    return res.data;
-  };
+  const getUserDM = async () => {
+    const { data } = await axios.get(`http://localhost:8080/chat/dm`);
+    if (data) {
+      setDMRooms([]);
+      data.map((room: any) => {
+        const friendName = getFriendNameFromRoomName(room.name);
+        const friend = room.members.filter((member: any) => member.user.name === friendName);
+
+        const newDMRoom = {
+          id: room.id,
+          name: friendName,
+          image: friend[0].user.image,
+        }
+        setDMRooms((prev: any) => [...prev, newDMRoom]);
+      })
+    }
+  }
 
   useEffect(() => {
     try {
       setLoading(true);
-      getUserDM().then((data) => {
-        setDMRooms([]);
-        data.map((room => setDMRooms((prev: any) => [...prev, { id: room.id, name: getFriendNameFromRoomName(room.name) }]))
-        )
-      })
+      getUserDM();
     } catch (error) {
       alert('DM取得に失敗しました。ブラウザをリフレッシュしてください');
     } finally {
@@ -94,7 +103,7 @@ export default function ChatFriendsComponent(props: ChatFriendsComponentProps) {
               className={'FriendListActive'}
             >
               <Grid item mr={2} ml={3}>
-                <Avatar ><PersonIcon /></Avatar>
+                <Avatar src={`${room.image}`} />
               </Grid>
               <Grid item>
                 <Typography variant="subtitle1">

--- a/frontend/src/components/chat/group/ChannelListComponent.tsx
+++ b/frontend/src/components/chat/group/ChannelListComponent.tsx
@@ -1,5 +1,4 @@
-import { Avatar, Box, CircularProgress, Grid, Typography } from "@mui/material";
-import PersonIcon from '@mui/icons-material/Person';
+import { Avatar, AvatarGroup, Box, CircularProgress, Grid, Typography } from "@mui/material";
 import axios from "axios";
 import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
@@ -52,7 +51,11 @@ export default function ChannelListComponent(props: ChannelListComponentProps) {
   if (Loading) {
     return (
       <>
-        <Box height={'3rem'} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Box
+          height={'3rem'}
+          sx={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center'
+        }}>
           <CircularProgress/>
         </Box>
       </>
@@ -74,7 +77,11 @@ export default function ChannelListComponent(props: ChannelListComponentProps) {
             className={'ChannelListActive'}
           >
             <Grid item mr={2} ml={3}>
-              <Avatar><PersonIcon /></Avatar>
+              <AvatarGroup max={3}>
+                {room.members?.map((member: any, id: number) => (
+                  <Avatar key={id} src={`${member.user.image}`} />
+                )) }
+              </AvatarGroup>
             </Grid>
             <Grid item>
               <Typography variant='subtitle1'>
@@ -94,7 +101,11 @@ export default function ChannelListComponent(props: ChannelListComponentProps) {
           className={'ChannelList'}
         >
           <Grid item mr={2} ml={3}>
-            <Avatar><PersonIcon /></Avatar>
+            <AvatarGroup max={3}>
+            {room.members?.map((member: any, id: number) => (
+                  <Avatar key={id} src={`${member.user.image}`} />
+                )) }
+            </AvatarGroup>
           </Grid>
           <Grid item>
             <Typography variant='subtitle1'>

--- a/frontend/src/components/chat/group/InvitationButton.tsx
+++ b/frontend/src/components/chat/group/InvitationButton.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Avatar, Button, Dialog, DialogActions, DialogContent, DialogTitle, Grid, Typography } from "@mui/material";
+import { Avatar, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Grid, Typography } from "@mui/material";
 import { Stack } from "@mui/system";
 import PersonIcon from '@mui/icons-material/Person';
 import axios from "axios";
@@ -66,8 +66,14 @@ export default function InvitationButton(props: InvitationButtonProps) {
 
   return (
     <>
-      <CustomButton fullWidth variant="contained" onClick={handleOpen}>
-        Invite your friend
+      <CustomButton
+        fullWidth
+        variant="contained"
+        onClick={handleOpen}
+      >
+        <Box sx={{ fontSize: '1vw' }}>
+          Invite your friend
+        </Box>
       </CustomButton>
       <Dialog open={isOpen}>
         <DialogTitle>Your Friends List</DialogTitle>

--- a/frontend/src/components/chat/utils/UserParticipantsList.tsx
+++ b/frontend/src/components/chat/utils/UserParticipantsList.tsx
@@ -1,5 +1,4 @@
 import { Avatar, Box, CircularProgress, Grid, Typography } from "@mui/material";
-import PersonIcon from '@mui/icons-material/Person';
 import axios from "axios";
 import { Link } from "react-router-dom";
 import React, {useEffect, useState } from "react";
@@ -11,6 +10,7 @@ type MemberPayload = {
   name: string;
   isMute: boolean;
   userId: string;
+  image: string;
   role: string;
 }
 
@@ -48,6 +48,7 @@ export default function UserParticipantList(props: UserParticipantListProps) {
             name: member.user.name,
             isMute: member.isMute,
             userId: member.user.id,
+            image: member.user.image,
             role: member.role
           }));
           setMembers(newMembers);
@@ -61,6 +62,7 @@ export default function UserParticipantList(props: UserParticipantListProps) {
       } finally {
         setTimeout(() => {
           setLoading(false);
+          console.log(members);
         }, 300);
       }
     }
@@ -93,7 +95,7 @@ export default function UserParticipantList(props: UserParticipantListProps) {
               <Grid container sx={{ display: 'flex', alignItems: 'center' }}>
                 <Grid item mr={2}>
                   <Link to={`/user/${member.userId}`}>
-                  <Avatar ><PersonIcon /></Avatar>
+                    <Avatar src={`${member.image}`} />
                   </Link>
                 </Grid>
                 <Grid item>

--- a/frontend/src/components/chat/utils/UserParticipantsList.tsx
+++ b/frontend/src/components/chat/utils/UserParticipantsList.tsx
@@ -62,7 +62,6 @@ export default function UserParticipantList(props: UserParticipantListProps) {
       } finally {
         setTimeout(() => {
           setLoading(false);
-          console.log(members);
         }, 300);
       }
     }

--- a/frontend/src/types/PrismaType.ts
+++ b/frontend/src/types/PrismaType.ts
@@ -16,6 +16,7 @@ export type User = {
 export type ChatRoom = {
   id: string
   name: string
+  image?: string
 }
 
 /**

--- a/frontend/src/types/PrismaType.ts
+++ b/frontend/src/types/PrismaType.ts
@@ -17,6 +17,7 @@ export type ChatRoom = {
   id: string
   name: string
   image?: string
+  members?: any[];
 }
 
 /**


### PR DESCRIPTION
## やったこと
- プロフィール画像を参加者リスト、DMなどで表示できるように変更
- 参加者のユーザ招待ボタンのレスポンシブ対応

## 次回アクション
- #219 
- #216 
- #217 

## 動作確認
```
DMorChannelを作成してユーザの画像が各所に表示されるか
```

## issues

about : #213 

close #213 