### PR TITLE
ブロック機能のバックエンドを実装

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,5 +1,5 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "linux-arm64-openssl-1.1.x"]
 }
 
@@ -23,9 +23,19 @@ model User {
   memberships        Member[]
   banned             BanUserOnChatRoom[]
   friendReqs         String[]
+  blockingUsers      BlockList[]         @relation("BlockerRelation")
+  blockedUsers       BlockList[]         @relation("BlockedRelation")
 }
 
+model BlockList {
+  id        String @id @default(uuid())
+  blockerId String
+  blocker   User   @relation("BlockerRelation", fields: [blockerId], references: [id])
+  blockedId String
+  blocked   User   @relation("BlockedRelation", fields: [blockedId], references: [id])
 
+  @@unique([blockerId, blockedId])
+}
 
 // TODO: auth.serviceでuserテーブルを操作したくないから、OneTimePasswordテーブルで別操作したい
 // model OneTimePassword {

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
+  ParseUUIDPipe,
   Patch,
   Post,
   Query,
@@ -48,7 +49,7 @@ export class ChatController {
   })
   async sendChat(
     @Req() req: Request,
-    @Param('id') roomId: string,
+    @Param('id', ParseUUIDPipe) roomId: string,
     @Body() dto: SendChatDto,
   ): Promise<Message> {
     return this.chatService.sendChat(req.user.id, roomId, dto);
@@ -88,14 +89,16 @@ export class ChatController {
     description: 'Get chat room by id',
     summary: 'Get chat room by id',
   })
-  async getChatRoomById(@Param('roomId') id: string): Promise<ChatRoom> {
+  async getChatRoomById(
+    @Param('roomId', ParseUUIDPipe) id: string,
+  ): Promise<ChatRoom> {
     return this.chatService.getChatRoomById(id);
   }
 
   @Get('room/:roomId/dm/friend')
   async getFriendNameByDMId(
     @Req() req: Request,
-    @Param('roomId') roomId: string,
+    @Param('roomId', ParseUUIDPipe) roomId: string,
   ): Promise<string> {
     return this.chatService.getFriendNameByDMId(req.user.id, roomId);
   }
@@ -110,7 +113,9 @@ export class ChatController {
     description: 'The chat logs',
     type: SwaggerMessages,
   })
-  async getChatLogByRoomId(@Param('roomId') id: string): Promise<Message[]> {
+  async getChatLogByRoomId(
+    @Param('roomId', ParseUUIDPipe) id: string,
+  ): Promise<Message[]> {
     return this.chatService.getChatLogByRoomId(id);
   }
 
@@ -143,7 +148,7 @@ export class ChatController {
   @Get(':roomId/myMember')
   async getMyMember(
     @Req() req: Request,
-    @Param('roomId') roomId: string,
+    @Param('roomId', ParseUUIDPipe) roomId: string,
   ): Promise<Member> {
     return this.chatService.getMyMember(req.user.id, roomId);
   }
@@ -176,7 +181,7 @@ export class ChatController {
   })
   async updateChannel(
     @Req() req: Request,
-    @Param('roomId') roomId: string,
+    @Param('roomId', ParseUUIDPipe) roomId: string,
     @Body() dto: CreateChatRoom,
   ) {
     return this.chatService.updateChannel(req.user.id, roomId, dto);

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,3 +1,11 @@
+import {
+  IsEmail,
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsArray,
+  IsUUID,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class SignUpUserDto {
@@ -23,4 +31,33 @@ export class FriendReq {
 export class AcceptFriend {
   @ApiProperty()
   friendId: string;
+}
+
+export class UserDto {
+  @ApiProperty()
+  @IsUUID()
+  id: string;
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+  @ApiProperty()
+  @IsString()
+  name: string;
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  twoFactorSecret?: string;
+  @ApiProperty()
+  @IsBoolean()
+  isTwoFactorEnabled: boolean;
+  @ApiProperty()
+  @IsString()
+  image: string;
+  @ApiProperty()
+  @IsBoolean()
+  isFtLogin: boolean;
+  @ApiProperty()
+  @IsArray()
+  @IsUUID(4, { each: true })
+  friendReqs: string[];
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Delete,
   Get,
+  HttpCode,
   HttpStatus,
   Param,
   Patch,
@@ -13,12 +14,11 @@ import {
 import { Controller } from '@nestjs/common';
 import { UserService } from './user.service';
 import { User } from '@prisma/client';
-import { ApiResponse, ApiTags } from '@nestjs/swagger';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PrismaUser, SwaggerFriends } from 'src/swagger/type';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
-import { AcceptFriend, FriendReq } from './dto/user.dto';
+import { AcceptFriend, UserDto } from './dto/user.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -141,5 +141,83 @@ export class UserController {
   @Get('image')
   async getUserImage(@Req() req: Request): Promise<string> {
     return this.userService.getUserImage(req.user.id);
+  }
+
+  /**
+   * Block
+   */
+  @ApiOperation({
+    summary: 'Block a user',
+    description: 'Adds the specified user ID to the block list.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Block successful',
+    type: UserDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'The user is trying to block themselves',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Specified user ID not found',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Block relationship already exists',
+  })
+  @Post('block/:userId')
+  @HttpCode(HttpStatus.OK)
+  async blockUser(
+    @Req() req: Request,
+    @Param('userId') userId: string,
+  ): Promise<User> {
+    return this.userService.blockUser(req.user.id, userId);
+  }
+
+  @ApiOperation({
+    summary: 'Unblock a user',
+    description: 'Removes the specified user ID from the block list.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the unblocked user',
+    type: UserDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'The user is trying to unblock themselves',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Specified user ID not found or block relationship not found',
+  })
+  @Delete('block/:userId')
+  @HttpCode(HttpStatus.OK)
+  async unblockUser(
+    @Req() req: Request,
+    @Param('userId') userId: string,
+  ): Promise<User> {
+    return this.userService.unblockUser(req.user.id, userId);
+  }
+
+  @ApiOperation({
+    summary: 'Get the block list of a user',
+    description: 'Retrieve the block list for the specified user ID.',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Returns an array of users included in the block list for the specified user ID',
+    type: [UserDto],
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Specified user ID not found',
+  })
+  @Get('block')
+  async getBlockList(@Req() req: Request): Promise<User[]> {
+    return this.userService.getBlockList(req.user.id);
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -147,6 +147,26 @@ export class UserController {
    * Block
    */
   @ApiOperation({
+    summary: 'Check if a user is blocked',
+    description: 'Determine whether the specified user ID is blocked.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'A boolean value indicating if the user is blocked',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'The specified user ID does not exist',
+  })
+  @Get('block/:userId')
+  async isUserBlocked(
+    @Req() req: Request,
+    @Param('userId') userId: string,
+  ): Promise<boolean> {
+    return this.userService.isUserBlocked(req.user.id, userId);
+  }
+
+  @ApiOperation({
     summary: 'Block a user',
     description: 'Adds the specified user ID to the block list.',
   })

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseUUIDPipe,
   Patch,
   Post,
   Query,
@@ -155,13 +156,17 @@ export class UserController {
     description: 'A boolean value indicating if the user is blocked',
   })
   @ApiResponse({
+    status: 400,
+    description: 'The specified user ID is not a valid UUID',
+  })
+  @ApiResponse({
     status: 404,
     description: 'The specified user ID does not exist',
   })
   @Get('block/:userId')
   async isUserBlocked(
     @Req() req: Request,
-    @Param('userId') userId: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
   ): Promise<boolean> {
     return this.userService.isUserBlocked(req.user.id, userId);
   }
@@ -191,7 +196,7 @@ export class UserController {
   @HttpCode(HttpStatus.OK)
   async blockUser(
     @Req() req: Request,
-    @Param('userId') userId: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
   ): Promise<User> {
     return this.userService.blockUser(req.user.id, userId);
   }
@@ -217,7 +222,7 @@ export class UserController {
   @HttpCode(HttpStatus.OK)
   async unblockUser(
     @Req() req: Request,
-    @Param('userId') userId: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
   ): Promise<User> {
     return this.userService.unblockUser(req.user.id, userId);
   }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,7 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { User } from '@prisma/client';
-import { FriendReq } from './dto/user.dto';
 
 @Injectable()
 export class UserService {
@@ -259,5 +263,129 @@ export class UserService {
         },
       });
     });
+  }
+
+  /******************
+   ***** Block ******
+   ******************/
+
+  /**
+   * ブロックリストにエントリを追加してユーザーをブロックする。
+   * @param blockerId ブロックするユーザーのID
+   * @param blockedId ブロックされるユーザーのID
+   * @returns ブロック関係が作成された後、ブロックしたユーザーのUserインスタンス
+   */
+  async blockUser(blockerId: string, blockedId: string): Promise<User> {
+    // blockerIdとblockedIdが同じであればエラー
+    if (blockerId === blockedId) {
+      throw new BadRequestException('You cannot block yourself.');
+    }
+    // blokerId、blockedIdのUserがいるか存在確認
+    const blocker = await this.prisma.user.findUnique({
+      where: { id: blockerId },
+    });
+    if (!blocker) {
+      throw new NotFoundException(`User with ID "${blockerId}" not found.`);
+    }
+    const blocked = await this.prisma.user.findUnique({
+      where: { id: blockedId },
+    });
+    if (!blocked) {
+      throw new NotFoundException(`User with ID "${blockedId}" not found.`);
+    }
+    // 既にブロック関係があるか確認
+    const isExistingBlock = await this.prisma.blockList.findUnique({
+      where: {
+        blockerId_blockedId: {
+          blockerId: blockerId,
+          blockedId: blockedId,
+        },
+      },
+    });
+    if (isExistingBlock) {
+      throw new ConflictException('The block relationship already exists.');
+    }
+    // BlockListテーブルにブロック関係を追加
+    await this.prisma.blockList.create({
+      data: {
+        blockerId: blockerId,
+        blockedId: blockedId,
+      },
+    });
+    return blocker;
+  }
+
+  /**
+   * ブロックリストからエントリを削除してユーザーのブロックを解除する。
+   * @param blockerId ブロックを解除したいユーザーのID
+   * @param blockedId ブロック解除されるユーザーのID
+   * @returns ブロック関係が削除された後、ブロックを解除したユーザーのUserインスタンス
+   */
+  async unblockUser(blockerId: string, blockedId: string): Promise<User> {
+    // blockerIdとblockedIdが同じであればエラー
+    if (blockerId === blockedId) {
+      throw new BadRequestException('You cannot block yourself.');
+    }
+    // blokerId、blockedIdのUserがいるか存在確認
+    const blocker = await this.prisma.user.findUnique({
+      where: { id: blockerId },
+    });
+    if (!blocker) {
+      throw new NotFoundException(`User with ID "${blockerId}" not found.`);
+    }
+    const blocked = await this.prisma.user.findUnique({
+      where: { id: blockedId },
+    });
+    if (!blocked) {
+      throw new NotFoundException(`User with ID "${blockedId}" not found.`);
+    }
+
+    try {
+      // BlockListテーブルからブロック関係を削除
+      await this.prisma.blockList.delete({
+        where: {
+          blockerId_blockedId: {
+            blockerId: blockerId,
+            blockedId: blockedId,
+          },
+        },
+      });
+    } catch (error) {
+      // 削除しようとしたブロック関係が見つからなかった場合、エラーを返す
+      if (error.code === 'P2025') {
+        throw new NotFoundException(
+          `Block relation between user with ID "${blockerId}" and user with ID "${blockedId}" not found.`,
+        );
+      } else {
+        throw error;
+      }
+    }
+
+    return blocker;
+  }
+
+  /**
+   * 指定されたユーザーIDのブロックリストを取得する。
+   * @param userId ブロックリストを取得したいユーザーのID
+   * @returns 指定されたユーザーIDのブロックリストに含まれるユーザーの配列
+   */
+  async getBlockList(userId: string): Promise<User[]> {
+    // userIdのUserがいるか存在確認
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: {
+        blockingUsers: {
+          include: {
+            blocked: true,
+          },
+        },
+      },
+    });
+    if (!user) {
+      throw new NotFoundException(`User with ID "${userId}" not found.`);
+    }
+
+    // ブロックリストに含まれるユーザーの配列を返す
+    return user.blockingUsers.map((blocklist) => blocklist.blocked);
   }
 }


### PR DESCRIPTION
## やったこと
ブロック機能バックエンド実装
エンドポイント

- POST /user/block/{userId}  userIdをブロック
- DELETE /user/block/{userId} userIdをブロック解除
- GET /user/block ブロックしているユーザのリストを取得
- GET /user/block/{userId} userIdのユーザをブロックしているかどうか判定する

## やらないこと

- フロントエンド実装
- #211 

## 動作確認

- 複数ユーザ作成、任意のユーザーでログイン後
- ブロック
![スクリーンショット 2023-04-07 0 06 13](https://user-images.githubusercontent.com/60804160/230420979-c801ae74-47b0-4f80-8900-c607e619a725.png)
- ブロック解除
![スクリーンショット 2023-04-07 0 06 23](https://user-images.githubusercontent.com/60804160/230421101-7022c584-d744-4306-8dab-9d4d241cd74b.png)

ブロックとブロック解除についてはurlにuseridを含めているのに注意してください。bodyは使ってません。

- ブロックリスト取得
![スクリーンショット 2023-04-07 0 06 31](https://user-images.githubusercontent.com/60804160/230421164-1bf754b1-4cb8-4d08-b756-62ccaa698d3b.png)


## その他

- swaggerとuser.service.tsにコメント残したので、使う時は参照してください！
わからないところあれば聞いて

## issues

about : #201

see also: #232 

close #201, #232
