### PR TITLE
[Profile]フレンド申請周りを実装

### DIFF
--- a/backend/src/auth/strategy/ft.strategy.ts
+++ b/backend/src/auth/strategy/ft.strategy.ts
@@ -2,7 +2,7 @@ import { HttpException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { User } from '@prisma/client';
-import { Strategy, Profile } from 'passport-42';
+import { Strategy, MyProfile } from 'passport-42';
 import { AuthService } from '../auth.service';
 
 @Injectable()
@@ -22,7 +22,7 @@ export class FtStrategy extends PassportStrategy(Strategy, '42') {
   async validate(
     accessToken: string,
     refreshToken: string,
-    profile: Profile,
+    profile: MyProfile,
   ): Promise<User> {
     const image = await this.authService.convertURLToBase64(
       profile._json.image.link,

--- a/backend/src/auth/strategy/ft.strategy.ts
+++ b/backend/src/auth/strategy/ft.strategy.ts
@@ -1,8 +1,8 @@
-import { HttpException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { User } from '@prisma/client';
-import { Strategy, MyProfile } from 'passport-42';
+import { Profile, Strategy } from 'passport-42';
 import { AuthService } from '../auth.service';
 
 @Injectable()
@@ -22,7 +22,7 @@ export class FtStrategy extends PassportStrategy(Strategy, '42') {
   async validate(
     accessToken: string,
     refreshToken: string,
-    profile: MyProfile,
+    profile: Profile,
   ): Promise<User> {
     const image = await this.authService.convertURLToBase64(
       profile._json.image.link,

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -44,8 +44,8 @@ export class UserController {
    * @param id
    * idによってuser情報を取得できるようなエンドポイント
    */
-  @Get('id')
-  async getUserById(@Query('id') id: string): Promise<User> {
+  @Post('id')
+  async getUserById(@Body('id') id: string): Promise<User> {
     return this.userService.getUserById(id);
   }
   @Patch('friend')

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,20 +1,18 @@
 import {
   Body,
+  Controller,
   Delete,
   Get,
   HttpStatus,
-  Param,
   Patch,
   Post,
   Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
-import { Controller } from '@nestjs/common';
 import { UserService } from './user.service';
 import { User } from '@prisma/client';
-import { ApiResponse, ApiTags } from '@nestjs/swagger';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PrismaUser, SwaggerFriends } from 'src/swagger/type';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
@@ -40,14 +38,20 @@ export class UserController {
     return req.user;
   }
 
-  /**
-   * @param id
-   * idによってuser情報を取得できるようなエンドポイント
-   */
-  @Post('id')
-  async getUserById(@Body('id') id: string): Promise<User> {
+  @Get('other')
+  @ApiOperation({
+    description: 'find other user by userId',
+    summary: 'find other user by userId',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'The found the other user',
+    type: PrismaUser,
+  })
+  async getUserById(@Query('id') id: string): Promise<User> {
     return this.userService.getUserById(id);
   }
+
   @Patch('friend')
   @ApiOperation({
     description:
@@ -84,7 +88,7 @@ export class UserController {
     @Req() req: Request,
     @Body() data: { friendId: string },
   ): Promise<User> {
-    this.userService.deleteFriend(data.friendId, req.user.id);
+    await this.userService.deleteFriend(data.friendId, req.user.id);
     return this.userService.deleteFriend(req.user.id, data.friendId);
   }
 
@@ -118,6 +122,7 @@ export class UserController {
     @Req() req: Request,
     @Body() friendId: AcceptFriend,
   ): Promise<User> {
+    console.log('backend', req.user.id, friendId.friendId);
     return this.userService.acceptFriendreq(req.user.id, friendId.friendId);
   }
 
@@ -139,6 +144,7 @@ export class UserController {
   ): Promise<User[]> {
     return this.userService.searchFriend(req.user.id, name);
   }
+
   @Post('add/image')
   async addUserImage(
     @Req() req: Request,
@@ -146,10 +152,12 @@ export class UserController {
   ): Promise<User> {
     return this.userService.addUserImage(req.user.id, data.image);
   }
+
   @Get('image')
   async getUserImage(@Req() req: Request): Promise<string> {
     return this.userService.getUserImage(req.user.id);
   }
+
   @Get('name')
   async searchFriendByName(@Query('name') name: string): Promise<User> {
     return this.userService.searchFriendByName(name);

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -18,7 +18,7 @@ import { ApiOperation } from '@nestjs/swagger';
 import { PrismaUser, SwaggerFriends } from 'src/swagger/type';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
-import { AcceptFriend, FriendReq } from './dto/user.dto';
+import { AcceptFriend } from './dto/user.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -40,6 +40,14 @@ export class UserController {
     return req.user;
   }
 
+  /**
+   * @param id
+   * idによってuser情報を取得できるようなエンドポイント
+   */
+  @Get('id')
+  async getUserById(@Query('id') id: string): Promise<User> {
+    return this.userService.getUserById(id);
+  }
   @Patch('friend')
   @ApiOperation({
     description:

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { User } from '@prisma/client';
-import { FriendReq } from './dto/user.dto';
 
 @Injectable()
 export class UserService {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,17 +10,11 @@ import Channel from "./features/channel/Channel";
 import ChannelComponent from "./components/chat/group/ChannelComponent";
 import ChannelWindowComponent from "./components/chat/group/ChannelWindowComponent";
 import GameMatching from "./features/game/GameMatching";
-import GamePlayer1 from "./features/game/GamePlayer1";
-import GamePlayer2 from "./features/game/GamePlayer2";
-import GameObserver from "./features/game/GameObserver";
-import CreateGameRoom from "./features/game/CreateGameRoom";
-import GameSelectRoom from "./features/game/GameSelectRoom";
-import InviteRoom from "./features/game/InviteRoom";
-import JoinInvitedRoom from "./features/game/JoinInvitedRoom";
 import NewNavBar from './components/utils/NewNavbar';
 import PrivateRouter from "./utils/PrivateRouter";
 import ProfileRouting from "./features/profile/ProfileRouting";
 import MyProfile from "./features/profile/MyProfile";
+import GameRouting from "./features/game/GameRouting";
 
 
 function App() {
@@ -53,14 +47,10 @@ function App() {
               <Route path=":roomId" element={<ChannelWindowComponent />} />
             </Route>
           </Route>
-          <Route path="/game" element={<GameMatching />} />
-            <Route path="/game/player1" element={<GamePlayer1/>} />
-            <Route path="/game/player2" element={<GamePlayer2/>} />
-          <Route path="/game/observer" element={<GameObserver/>} />
-          <Route path="/game/select_room" element={<GameSelectRoom/>} />
-          <Route path="/game/game_room" element={<CreateGameRoom/>} />
-          <Route path="/game/invite_room" element={<InviteRoom/>} />
-          <Route path="/game/join_invited_room" element={<JoinInvitedRoom></JoinInvitedRoom>} />
+          <Route>
+            <Route path="/game" element={<GameMatching />} />
+            <Route path={"/game/:room"} element={<GameRouting />} />
+          </Route>
           <Route path={"/user"} element={<MyProfile />}/>
           <Route path={"/user/:name"} element={<ProfileRouting />}/>
         </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import JoinInvitedRoom from "./features/game/JoinInvitedRoom";
 import NewNavBar from './components/utils/NewNavbar';
 import PrivateRouter from "./utils/PrivateRouter";
 import ProfileRouting from "./features/profile/ProfileRouting";
-import Profile from "./features/profile/Profile";
+import MyProfile from "./features/profile/MyProfile";
 
 
 function App() {
@@ -61,7 +61,7 @@ function App() {
           <Route path="/game/game_room" element={<CreateGameRoom/>} />
           <Route path="/game/invite_room" element={<InviteRoom/>} />
           <Route path="/game/join_invited_room" element={<JoinInvitedRoom></JoinInvitedRoom>} />
-          <Route path={"/user"} element={<Profile />}/>
+          <Route path={"/user"} element={<MyProfile />}/>
           <Route path={"/user/:name"} element={<ProfileRouting />}/>
         </Routes>
       </Grid>

--- a/frontend/src/components/profile/FriendListButton.tsx
+++ b/frontend/src/components/profile/FriendListButton.tsx
@@ -10,7 +10,7 @@ const FriendListButton = (props: FriendListButtonProps) => {
 
     return (
         <>
-            Hello
+
         </>
     );
 }

--- a/frontend/src/components/profile/FriendRequestButton.tsx
+++ b/frontend/src/components/profile/FriendRequestButton.tsx
@@ -12,7 +12,7 @@ const FriendRequestButton = (props: FriendRequestButtonProps) => {
     const [isFollowing, setIsFollowing] = useState(false);
     // const [loginUser, setLoginUser] = useState<User>();
 
-    /* 自分が誰なのかという情報 */
+    // /* 自分が誰なのかという情報 */
     // useEffect(() => {
     //     const UserPromises = fetchProfileUser();
     //     UserPromises.then((userDto: User) => {

--- a/frontend/src/components/profile/FriendRequestButton.tsx
+++ b/frontend/src/components/profile/FriendRequestButton.tsx
@@ -1,15 +1,40 @@
-import React, { useState } from "react";
+import React, { useState} from "react";
 import { Button } from "@mui/material";
+import axios from "axios";
+// import fetchProfileUser from "../../hooks/profile/useProfileUser"
+import { User } from '../../types/PrismaType';
 
-const FriendRequestButton = () => {
+interface FriendRequestButtonProps {
+    user: User | undefined;
+}
+
+const FriendRequestButton = (props: FriendRequestButtonProps) => {
     const [isFollowing, setIsFollowing] = useState(false);
+    // const [loginUser, setLoginUser] = useState<User>();
+
+    /* 自分が誰なのかという情報 */
+    // useEffect(() => {
+    //     const UserPromises = fetchProfileUser();
+    //     UserPromises.then((userDto: User) => {
+    //         setLoginUser(userDto);
+    //     });
+    // }, []);
+
 
     const handleClick = () => {
         console.log("Friend Request Button");
         setIsFollowing(!isFollowing);
-    };
 
-    /* 既存APIを用いて、friend reqを調整する */
+
+        /* login user -> other peopleに対してfriend requestを送信する */
+        axios.post(`http://localhost:8080/user/friendReq`, {
+            friendId: props.user?.id,
+        }).then((res) => {
+            console.log('success!', res);
+        }, (err) => {
+            console.log('error!', err);
+        },);
+    };
 
     return (
         <>

--- a/frontend/src/components/profile/FriendRequestButton.tsx
+++ b/frontend/src/components/profile/FriendRequestButton.tsx
@@ -9,6 +9,8 @@ const FriendRequestButton = () => {
         setIsFollowing(!isFollowing);
     };
 
+    /* 既存APIを用いて、friend reqを調整する */
+
     return (
         <>
             <Button

--- a/frontend/src/components/profile/FriendRequestButton.tsx
+++ b/frontend/src/components/profile/FriendRequestButton.tsx
@@ -1,52 +1,51 @@
-import React, { useState} from "react";
-import { Button } from "@mui/material";
-import axios from "axios";
+import React, { useState } from 'react';
+import { Button } from '@mui/material';
+import axios from 'axios';
 // import fetchProfileUser from "../../hooks/profile/useProfileUser"
 import { User } from '../../types/PrismaType';
 
 interface FriendRequestButtonProps {
-    user: User | undefined;
+  user: User | undefined;
 }
 
 const FriendRequestButton = (props: FriendRequestButtonProps) => {
-    const [isFollowing, setIsFollowing] = useState(false);
-    // const [loginUser, setLoginUser] = useState<User>();
+  const [isFriendRequest, setIsFriendRequest] = useState(false);
+  // const [loginUser, setLoginUser] = useState<User>();
 
-    // /* 自分が誰なのかという情報 */
-    // useEffect(() => {
-    //     const UserPromises = fetchProfileUser();
-    //     UserPromises.then((userDto: User) => {
-    //         setLoginUser(userDto);
-    //     });
-    // }, []);
+  // /* 自分が誰なのかという情報 */
+  // useEffect(() => {
+  //     const UserPromises = fetchProfileUser();
+  //     UserPromises.then((userDto: User) => {
+  //         setLoginUser(userDto);
+  //     });
+  // }, []);
 
+  const handleClick = () => {
+    console.log('Friend Request Button');
+    setIsFriendRequest(!isFriendRequest);
 
-    const handleClick = () => {
-        console.log("Friend Request Button");
-        setIsFollowing(!isFollowing);
+    /* login user -> other peopleに対してfriend requestを送信する */
+    axios
+      .post(`http://localhost:8080/user/friendReq`, {
+        friendId: props.user?.id,
+      })
+      .then(
+        (res) => {
+          console.log('success!', res);
+        },
+        (err) => {
+          console.log('error!', err);
+        },
+      );
+  };
 
-
-        /* login user -> other peopleに対してfriend requestを送信する */
-        axios.post(`http://localhost:8080/user/friendReq`, {
-            friendId: props.user?.id,
-        }).then((res) => {
-            console.log('success!', res);
-        }, (err) => {
-            console.log('error!', err);
-        },);
-    };
-
-    return (
-        <>
-            <Button
-                variant="contained"
-                size={"large"}
-                onClick={handleClick}
-            >
-                {isFollowing ? "Unfollow" : "Follow"}
-            </Button>
-        </>
-    );
+  return (
+    <>
+      <Button variant="contained" size={'large'} onClick={handleClick}>
+        {isFriendRequest ? '' : 'Friend Request'}
+      </Button>
+    </>
+  );
 };
 
 export default FriendRequestButton;

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -7,49 +7,47 @@ import {User} from "../../types/PrismaType";
 
 const NotificationButton = () => {
     const [friendIds, setFriendIds] = useState<string[]>([]);
+    const [friends, setFriends] = useState<User[]>([]);
     const [nbNotification, setNbNotification] = useState<number>(0);
     const [showRequests, setShowRequests] = useState<boolean>(false);
-    const [user, setUser] = useState<User>();
+    // const [user, setUser] = useState<User>();
 
     useEffect(() => {
-        const people = axios.get<string[]>(`http://localhost:8080/user/friendReq`);
-        people.then((res) => {
+        /* requestしてきたpeopleをfetch */
+        const reqPeople = axios.get<string[]>(`http://localhost:8080/user/friendReq`);
+        reqPeople.then((res) => {
             setFriendIds(res.data);
             setNbNotification(res.data.length);
         });
     }, []);
 
-
-    const ItemToName = (item: string) => {
-        const otherPerson = axios.get<User>(`http://localhost:8080/user/id`, {
-            params: {
-                id: item
-            }
+    useEffect(() => {
+        // friendIdsに応じたidからuserを取得して、friendsに格納していく
+        friendIds.forEach((id) => {
+            const friend = axios.post<User>(`http://localhost:8080/user/id`, {id});
+            console.log(friend);
+            friend.then((res) => {
+                setFriends((prev) => [...prev, res.data]);
+            });
         });
-        otherPerson.then((res) => {
-            setUser(res.data);
-            console.log(res.data);
-            console.log(user);
-            return res.data.name;
-        }, (err) => {
-            console.log(err);
-        });
-        return "error";
-    }
+    }, [friendIds]);
 
-    const OpenRequests = (props: { ss: string[] }) => {
-        const items = props.ss;
 
-        return (
-            <>
-                {items.map((item, index) => (
-                    <li key={index}>{ItemToName(item)}</li>
-                ))}
-            </>
-        );
-    }
+    // fs is an array of friend
+    const OpenRequests = () => (
+        <div>
+            {friends.map((f) => (
+                <React.Fragment key={f.id}>
+                    <p>{f.name}</p>
+                    <button>Accept</button>
+                    <button>Decline</button>
+                </React.Fragment>
+            ))}
+        </div>
+    );
 
     const handleClick = () => {
+        console.log("clicked");
         setShowRequests(!showRequests);
     }
 
@@ -73,8 +71,7 @@ const NotificationButton = () => {
                 />
             </Badge>
             <Grid>
-            {showRequests && (<OpenRequests ss={friendIds}/>
-            )}
+            {showRequests && (<OpenRequests/>)}
             </Grid>
         </Grid>
     )

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -1,28 +1,60 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {Badge } from '@mui/material';
 import Grid from '@mui/material/Grid';
+import axios from 'axios';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 
 const NotificationButton = () => {
-    console.log('notification button');
+    const [friendIds, setFriendIds] = useState<string[]>([]);
+    const [showRequests, setShowRequests] = useState<boolean>(false);
+
+    useEffect(() => {
+        const people = axios.get<string[]>(`http://localhost:8080/user/friendReq`);
+        people.then((res) => {
+            setFriendIds(res.data);
+        });
+    }, []);
+
+    const OpenRequests = (props: { ss: string[] }) => {
+        const items = props.ss;
+
+        return (
+            <ul>
+                {items.map((item, index) => (
+                    <li key={index}>{item}</li>
+                ))}
+            </ul>
+        );
+    }
+
+    const handleClick = () => {
+        setShowRequests(!showRequests);
+    }
+
     return (
         <Grid item xs={4}>
-        <Badge
-            badgeContent={4}
-            color={"error"}
-            overlap="circular"
-            anchorOrigin={{
-                vertical: "top",
-                horizontal: "right",
-            }}
-        >
-            <NotificationsIcon
-                sx={{
-                    color: "blue",
-                    fontSize: "4rem",
+            <Badge
+                color={"error"}
+                overlap="circular"
+                badgeContent={friendIds.length}
+                anchorOrigin={{
+                    vertical: "top",
+                    horizontal: "right",
                 }}
-            />
-        </Badge>
+            >
+                <NotificationsIcon
+                    sx={{
+                        color: "blue",
+                        fontSize: "4rem",
+                    }}
+                    onClick={handleClick}
+                />
+            </Badge>
+            {showRequests && (
+                <div>
+                    <OpenRequests ss={friendIds}/>
+                </div>
+            )}
         </Grid>
     )
 }

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -55,8 +55,18 @@ const NotificationButton = () => {
         })
     }
 
-    const handleDecline = () => {
-        console.log("decline");
+    const handleDecline = (declinePersonId: string) => {
+        console.log("decline", declinePersonId);
+        // @delete http://localhost:8080/user/friendReqでacceptできる
+        // bodyはfriend idのみ
+        const res = axios.delete<User>('http://localhost:8080/user/friendReq', {
+            data: {friendId: declinePersonId}
+        });
+        res.then((response) => {
+            console.log(response);
+        }).catch((err) => {
+            console.log(err);
+        })
     }
 
     // fs is an array of friend
@@ -91,7 +101,7 @@ const NotificationButton = () => {
                         <Button
                             variant="outlined"
                             color="error"
-                            onClick={handleDecline}
+                            onClick={() => handleDecline(f.id)}
                         >
                             Decline
                         </Button>

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -35,10 +35,16 @@ const NotificationButton = () => {
 
     // fs is an array of friend
     const OpenRequests = () => (
-        <div>
+        <div
+            style={{
+                position: "absolute",
+                color: "#B2B9C5"
+            }}
+        >
             {friends.map((f) => (
-                <React.Fragment key={f.id}>
-                    <p>{f.name}</p>
+                <React.Fragment
+                    key={f.id}>
+                    <h2>・friend request from {f.name}</h2>
                     <Button
                         variant="contained"
                     >

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -1,9 +1,17 @@
-import React, {useEffect, useState} from 'react';
-import {Badge, Button } from '@mui/material';
-import NotificationsIcon from '@mui/icons-material/Notifications';
-import Grid from '@mui/material/Grid';
-import axios from 'axios';
-import {User} from "../../types/PrismaType";
+import React, { useEffect, useState } from "react";
+import {
+    Badge,
+    Button,
+    Card,
+    CardContent,
+    CardActions,
+    Typography,
+} from "@mui/material";
+import { Box } from "@mui/system";
+import NotificationsIcon from "@mui/icons-material/Notifications";
+import Grid from "@mui/material/Grid";
+import axios from "axios";
+import { User } from "../../types/PrismaType";
 
 const NotificationButton = () => {
     const [friendIds, setFriendIds] = useState<string[]>([]);
@@ -35,30 +43,38 @@ const NotificationButton = () => {
 
     // fs is an array of friend
     const OpenRequests = () => (
-        <div
+        <Box
             style={{
                 position: "absolute",
-                color: "#B2B9C5"
+                color: "#B2B9C5",
+                maxWidth: "400px",
             }}
         >
             {friends.map((f) => (
-                <React.Fragment
-                    key={f.id}>
-                    <h2>・friend request from {f.name}</h2>
-                    <Button
-                        variant="contained"
-                    >
-                        Accept
-                    </Button>
-                    <Button
-                        variant="outlined"
-                    >
-                        Decline
-                    </Button>
-                </React.Fragment>
+                <Card
+                    key={f.id}
+                    sx={{
+                        marginBottom: "1rem",
+                        backgroundColor: "#EDF0F4",
+                }}>
+                    <CardContent>
+                        <Typography variant="h6" component="h2">
+                            Friend request from {f.name}
+                        </Typography>
+                    </CardContent>
+                    <CardActions>
+                        <Button variant="contained" color="success">
+                            Accept
+                        </Button>
+                        <Button variant="outlined" color="error">
+                            Decline
+                        </Button>
+                    </CardActions>
+                </Card>
             ))}
-        </div>
+        </Box>
     );
+
 
     const handleClick = () => {
         console.log("clicked");

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -1,146 +1,156 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState } from 'react';
 import {
-    Badge,
-    Button,
-    Card,
-    CardContent,
-    CardActions,
-    Typography,
-} from "@mui/material";
-import { Box } from "@mui/system";
-import NotificationsIcon from "@mui/icons-material/Notifications";
-import Grid from "@mui/material/Grid";
-import axios from "axios";
-import { User } from "../../types/PrismaType";
+  Badge,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Typography,
+} from '@mui/material';
+import { Box } from '@mui/system';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import Grid from '@mui/material/Grid';
+import axios from 'axios';
+import { User } from '../../types/PrismaType';
 
 const NotificationButton = () => {
-    const [friendIds, setFriendIds] = useState<string[]>([]);
-    const [friends, setFriends] = useState<User[]>([]);
-    const [nbNotification, setNbNotification] = useState<number>(0);
-    const [showRequests, setShowRequests] = useState<boolean>(false);
-    // const [user, setUser] = useState<User>();
+  const [friendIds, setFriendIds] = useState<string[]>([]);
+  const [friends, setFriends] = useState<User[]>([]);
+  const [nbNotification, setNbNotification] = useState<number>(0);
+  const [showRequests, setShowRequests] = useState<boolean>(false);
+  // const [user, setUser] = useState<User>();
 
-    useEffect(() => {
-        /* requestしてきたpeopleをfetch */
-        const reqPeople = axios.get<string[]>(`http://localhost:8080/user/friendReq`);
-        reqPeople.then((res) => {
-            setFriendIds(res.data);
-            setNbNotification(res.data.length);
-        });
-    }, []);
-
-    useEffect(() => {
-        // friendIdsに応じたidからuserを取得して、friendsに格納していく
-        friendIds.forEach((id) => {
-            const friend = axios.post<User>(`http://localhost:8080/user/id`, {id});
-            console.log(friend);
-            friend.then((res) => {
-                setFriends((prev) => [...prev, res.data]);
-            });
-        });
-    }, [friendIds]);
-
-    // [memo]
-    // accept or declineをしたuserに関してはfriendReqから削除するAPIが必要になる
-
-    const handleAccept = (acceptPersonId: string) => {
-        console.log("accept", acceptPersonId);
-        // @patch http://localhost:8080/user/friendReqでacceptできる
-        // bodyはfriend idのみ
-        const res = axios.patch<User>('http://localhost:8080/user/friendReq', {friendId: acceptPersonId});
-        res.then((response) => {
-            console.log(response);
-        }).catch((err) => {
-            console.log(err);
-        })
-    }
-
-    const handleDecline = (declinePersonId: string) => {
-        console.log("decline", declinePersonId);
-        // @delete http://localhost:8080/user/friendReqでacceptできる
-        // bodyはfriend idのみ
-        const res = axios.delete<User>('http://localhost:8080/user/friendReq', {
-            data: {friendId: declinePersonId}
-        });
-        res.then((response) => {
-            console.log(response);
-        }).catch((err) => {
-            console.log(err);
-        })
-    }
-
-    // fs is an array of friend
-    const OpenRequests = () => (
-        <Box
-            style={{
-                position: "absolute",
-                color: "#B2B9C5",
-                maxWidth: "400px",
-            }}
-        >
-            {friends.map((f) => (
-                <Card
-                    key={f.id}
-                    sx={{
-                        marginBottom: "1rem",
-                        backgroundColor: "#EDF0F4",
-                }}>
-                    <CardContent>
-                        <Typography variant="h6" component="h2">
-                            Friend request from {f.name}
-                        </Typography>
-                    </CardContent>
-                    <CardActions>
-                        <Button
-                            variant="contained"
-                            color="success"
-                            onClick={() => handleAccept(f.id)}
-                        >
-                            Accept
-                        </Button>
-                        <Button
-                            variant="outlined"
-                            color="error"
-                            onClick={() => handleDecline(f.id)}
-                        >
-                            Decline
-                        </Button>
-                    </CardActions>
-                </Card>
-            ))}
-        </Box>
+  useEffect(() => {
+    /* requestしてきたpeopleをfetch */
+    const reqPeople = axios.get<string[]>(
+      `http://localhost:8080/user/friendReq`,
     );
+    reqPeople.then((res) => {
+      setFriendIds(res.data);
+      setNbNotification(res.data.length);
+    });
+  }, []);
 
+  useEffect(() => {
+    // friendIdsに応じたidからuserを取得して、friendsに格納していく
+    friendIds.forEach((id) => {
+      const friend = axios.get<User>(`http://localhost:8080/user/other`, {
+        params: {
+          id,
+        },
+      });
+      console.log(friend);
+      friend.then((res) => {
+        setFriends((prev) => [...prev, res.data]);
+      });
+    });
+  }, [friendIds]);
 
-    const handleClick = () => {
-        console.log("clicked");
-        setShowRequests(!showRequests);
-    }
+  // [memo]
+  // accept or declineをしたuserに関してはfriendReqから削除するAPIが必要になる
 
-    return (
-        <Grid item xs={5}>
-            <Badge
-                color={"error"}
-                overlap="circular"
-                badgeContent={nbNotification}
-                anchorOrigin={{
-                    vertical: "top",
-                    horizontal: "right",
-                }}
+  const handleAccept = (acceptPersonId: string) => {
+    console.log('accept', acceptPersonId);
+    // @patch http://localhost:8080/user/friendReqでacceptできる
+    // bodyはfriend idのみ
+    const res = axios.patch<User>('http://localhost:8080/user/friendReq', {
+      friendId: acceptPersonId,
+    });
+    res
+      .then((response) => {
+        console.log(response);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  const handleDecline = (declinePersonId: string) => {
+    console.log('decline', declinePersonId);
+    // @delete http://localhost:8080/user/friendReqでacceptできる
+    // bodyはfriend idのみ
+    const res = axios.delete<User>('http://localhost:8080/user/friendReq', {
+      data: { friendId: declinePersonId },
+    });
+    res
+      .then((response) => {
+        console.log(response);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  // fs is an array of friend
+  const OpenRequests = () => (
+    <Box
+      style={{
+        position: 'absolute',
+        color: '#B2B9C5',
+        maxWidth: '400px',
+      }}
+    >
+      {friends.map((f) => (
+        <Card
+          key={f.id}
+          sx={{
+            marginBottom: '1rem',
+            backgroundColor: '#EDF0F4',
+          }}
+        >
+          <CardContent>
+            <Typography variant="h6" component="h2">
+              Friend request from {f.name}
+            </Typography>
+          </CardContent>
+          <CardActions>
+            <Button
+              variant="contained"
+              color="success"
+              onClick={() => handleAccept(f.id)}
             >
-                <NotificationsIcon
-                    sx={{
-                        color: "blue",
-                        fontSize: "4rem",
-                    }}
-                    onClick={handleClick}
-                />
-            </Badge>
-            <Grid>
-            {showRequests && (<OpenRequests/>)}
-            </Grid>
-        </Grid>
-    )
-}
+              Accept
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              onClick={() => handleDecline(f.id)}
+            >
+              Decline
+            </Button>
+          </CardActions>
+        </Card>
+      ))}
+    </Box>
+  );
+
+  const handleClick = () => {
+    console.log('clicked');
+    setShowRequests(!showRequests);
+  };
+
+  return (
+    <Grid item xs={5}>
+      <Badge
+        color={'error'}
+        overlap="circular"
+        badgeContent={nbNotification}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+      >
+        <NotificationsIcon
+          sx={{
+            color: 'blue',
+            fontSize: '4rem',
+          }}
+          onClick={handleClick}
+        />
+      </Badge>
+      <Grid>{showRequests && <OpenRequests />}</Grid>
+    </Grid>
+  );
+};
 
 export default NotificationButton;

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Badge } from '@mui/material';
+import {Badge, Button } from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import Grid from '@mui/material/Grid';
 import axios from 'axios';
@@ -39,8 +39,16 @@ const NotificationButton = () => {
             {friends.map((f) => (
                 <React.Fragment key={f.id}>
                     <p>{f.name}</p>
-                    <button>Accept</button>
-                    <button>Decline</button>
+                    <Button
+                        variant="contained"
+                    >
+                        Accept
+                    </Button>
+                    <Button
+                        variant="outlined"
+                    >
+                        Decline
+                    </Button>
                 </React.Fragment>
             ))}
         </div>

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -40,6 +40,24 @@ const NotificationButton = () => {
         });
     }, [friendIds]);
 
+    // [memo]
+    // accept or declineをしたuserに関してはfriendReqから削除するAPIが必要になる
+
+    const handleAccept = (acceptPersonId: string) => {
+        console.log("accept", acceptPersonId);
+        // @patch http://localhost:8080/user/friendReqでacceptできる
+        // bodyはfriend idのみ
+        const res = axios.patch<User>('http://localhost:8080/user/friendReq', {friendId: acceptPersonId});
+        res.then((response) => {
+            console.log(response);
+        }).catch((err) => {
+            console.log(err);
+        })
+    }
+
+    const handleDecline = () => {
+        console.log("decline");
+    }
 
     // fs is an array of friend
     const OpenRequests = () => (
@@ -63,10 +81,18 @@ const NotificationButton = () => {
                         </Typography>
                     </CardContent>
                     <CardActions>
-                        <Button variant="contained" color="success">
+                        <Button
+                            variant="contained"
+                            color="success"
+                            onClick={() => handleAccept(f.id)}
+                        >
                             Accept
                         </Button>
-                        <Button variant="outlined" color="error">
+                        <Button
+                            variant="outlined"
+                            color="error"
+                            onClick={handleDecline}
+                        >
                             Decline
                         </Button>
                     </CardActions>

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {Badge } from '@mui/material';
+import Grid from '@mui/material/Grid';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+
+const NotificationButton = () => {
+    console.log('notification button');
+    return (
+        <Grid item xs={4}>
+        <Badge
+            badgeContent={4}
+            color={"error"}
+            overlap="circular"
+            anchorOrigin={{
+                vertical: "top",
+                horizontal: "right",
+            }}
+        >
+            <NotificationsIcon
+                sx={{
+                    color: "blue",
+                    fontSize: "4rem",
+                }}
+            />
+        </Badge>
+        </Grid>
+    )
+}
+
+export default NotificationButton;

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -1,13 +1,15 @@
 import React, {useEffect, useState} from 'react';
 import {Badge } from '@mui/material';
+import NotificationsIcon from '@mui/icons-material/Notifications';
 import Grid from '@mui/material/Grid';
 import axios from 'axios';
-import NotificationsIcon from '@mui/icons-material/Notifications';
+import {User} from "../../types/PrismaType";
 
 const NotificationButton = () => {
     const [friendIds, setFriendIds] = useState<string[]>([]);
     const [nbNotification, setNbNotification] = useState<number>(0);
     const [showRequests, setShowRequests] = useState<boolean>(false);
+    const [user, setUser] = useState<User>();
 
     useEffect(() => {
         const people = axios.get<string[]>(`http://localhost:8080/user/friendReq`);
@@ -19,13 +21,20 @@ const NotificationButton = () => {
 
 
     const ItemToName = (item: string) => {
-        const name = axios.get<string>(`http://localhost:8080/user`, {
-            params: {id: item}
-        }).catch((err) => console.log(err));
-        name.then((res) =>
-            res?.data
-        );
-        return item;
+        const otherPerson = axios.get<User>(`http://localhost:8080/user/id`, {
+            params: {
+                id: item
+            }
+        });
+        otherPerson.then((res) => {
+            setUser(res.data);
+            console.log(res.data);
+            console.log(user);
+            return res.data.name;
+        }, (err) => {
+            console.log(err);
+        });
+        return "error";
     }
 
     const OpenRequests = (props: { ss: string[] }) => {

--- a/frontend/src/components/profile/NotificationButton.tsx
+++ b/frontend/src/components/profile/NotificationButton.tsx
@@ -6,24 +6,37 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 
 const NotificationButton = () => {
     const [friendIds, setFriendIds] = useState<string[]>([]);
+    const [nbNotification, setNbNotification] = useState<number>(0);
     const [showRequests, setShowRequests] = useState<boolean>(false);
 
     useEffect(() => {
         const people = axios.get<string[]>(`http://localhost:8080/user/friendReq`);
         people.then((res) => {
             setFriendIds(res.data);
+            setNbNotification(res.data.length);
         });
     }, []);
+
+
+    const ItemToName = (item: string) => {
+        const name = axios.get<string>(`http://localhost:8080/user`, {
+            params: {id: item}
+        }).catch((err) => console.log(err));
+        name.then((res) =>
+            res?.data
+        );
+        return item;
+    }
 
     const OpenRequests = (props: { ss: string[] }) => {
         const items = props.ss;
 
         return (
-            <ul>
+            <>
                 {items.map((item, index) => (
-                    <li key={index}>{item}</li>
+                    <li key={index}>{ItemToName(item)}</li>
                 ))}
-            </ul>
+            </>
         );
     }
 
@@ -32,11 +45,11 @@ const NotificationButton = () => {
     }
 
     return (
-        <Grid item xs={4}>
+        <Grid item xs={5}>
             <Badge
                 color={"error"}
                 overlap="circular"
-                badgeContent={friendIds.length}
+                badgeContent={nbNotification}
                 anchorOrigin={{
                     vertical: "top",
                     horizontal: "right",
@@ -50,11 +63,10 @@ const NotificationButton = () => {
                     onClick={handleClick}
                 />
             </Badge>
-            {showRequests && (
-                <div>
-                    <OpenRequests ss={friendIds}/>
-                </div>
+            <Grid>
+            {showRequests && (<OpenRequests ss={friendIds}/>
             )}
+            </Grid>
         </Grid>
     )
 }

--- a/frontend/src/features/game/GameRouting.tsx
+++ b/frontend/src/features/game/GameRouting.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import {useParams} from "react-router-dom";
+import GamePlayer1 from "./GamePlayer1";
+import GamePlayer2 from "./GamePlayer2";
+import GameObserver from "./GameObserver";
+import GameSelectRoom from "./GameSelectRoom";
+import CreateGameRoom from "./CreateGameRoom";
+import InviteRoom from "./InviteRoom";
+import JoinInvitedRoom from "./JoinInvitedRoom";
+
+
+const GameRouting = () => {
+    const {room} = useParams();
+    if (room === 'player1') {
+        return <GamePlayer1 />
+    }
+    if (room === 'player2') {
+        return <GamePlayer2 />
+    }
+    if (room === 'observer') {
+        return <GameObserver />
+    }
+    if (room === 'select_room') {
+        return <GameSelectRoom />
+    }
+    if (room === 'game_room') {
+        return <CreateGameRoom />
+    }
+    if (room === 'invite_room') {
+        return <InviteRoom />
+    }
+    if (room === 'join_invited_room') {
+        return <JoinInvitedRoom />
+    }
+
+    return <div>
+        <h1>
+            THIS PAGE IS NOT FOUND
+        </h1>
+    </div>
+}
+
+export default GameRouting;

--- a/frontend/src/features/profile/MyProfile.tsx
+++ b/frontend/src/features/profile/MyProfile.tsx
@@ -203,7 +203,6 @@ const MyProfile = () => {
         // );
     // }
     //
-    // const steveJobsImage = "https://cdn.profoto.com/cdn/053149e/contentassets/d39349344d004f9b8963df1551f24bf4/profoto-albert-watson-steve-jobs-pinned-image-original.jpg?width=1280&quality=75&format=jpg";
 
     const uploadImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
         const { files } = event.target;
@@ -243,10 +242,6 @@ const MyProfile = () => {
         });
     }, []);
 
-    // const handleFingerPrintButton = () => {
-    //     navigator.clipboard.writeText(user?.id as string);
-    // }
-    //
     // const FriendListButton = () => (
     //         <div>
     //             <Button
@@ -292,12 +287,11 @@ const MyProfile = () => {
                 >
                     [My Profile]
                 </Grid>
-                <Grid item xs={5}
-                      sx={{
-                          display: "flex",
-                            alignItems: "flex-end",
-                            justifyContent: "flex-end",
-                      }}
+                <Grid item xs={5} sx={{
+                    display: "flex",
+                    alignItems: "flex-end",
+                    justifyContent: "flex-end",
+                }}
                 >
                     <NotificationButton />
                 </Grid>

--- a/frontend/src/features/profile/MyProfile.tsx
+++ b/frontend/src/features/profile/MyProfile.tsx
@@ -11,9 +11,9 @@ import ShowAvatar from "../../components/profile/ShowAvatar";
 import ImageUploadButton from "../../components/profile/ImageUploadButton";
 import FingerPrintButton from "../../components/profile/FingerPrintButton";
 import InputFriendId from "../../components/profile/InputFriendId";
-import FriendProfile from "./FriendProfile";
+import OtherPeopleProfile from "./OtherPeopleProfile";
 
-const Profile = () => {
+const MyProfile = () => {
     const [user, setUser] = useState<User>();
     const socket = io("http://localhost:8080");
     const UserPromises = fetchProfileUser();
@@ -262,7 +262,7 @@ const Profile = () => {
                     <div key={friend.id}>
                         [{friend.name}]
                         <FriendStatus friendName={friend.name}/>
-                        <FriendProfile friend={friend} />
+                        <OtherPeopleProfile friend={friend} />
                     </div>
                 ))}
             </h3>
@@ -325,4 +325,4 @@ const Profile = () => {
 }
 
 
-export default Profile;
+export default MyProfile;

--- a/frontend/src/features/profile/MyProfile.tsx
+++ b/frontend/src/features/profile/MyProfile.tsx
@@ -10,6 +10,7 @@ import useQueryMatches from "../../hooks/match/useWueryMatch";
 import ShowAvatar from "../../components/profile/ShowAvatar";
 import ImageUploadButton from "../../components/profile/ImageUploadButton";
 // import OtherPeopleProfile from "./OtherPeopleProfile";
+import NotificationButton from "../../components/profile/NotificationButton";
 
 const MyProfile = () => {
     const [user, setUser] = useState<User>();
@@ -290,6 +291,15 @@ const MyProfile = () => {
                     }}
                 >
                     [My Profile]
+                </Grid>
+                <Grid item xs={5}
+                      sx={{
+                          display: "flex",
+                            alignItems: "flex-end",
+                            justifyContent: "flex-end",
+                      }}
+                >
+                    <NotificationButton />
                 </Grid>
                 <Grid item xs={5}>
                     <ShowAvatar user={user} profileImage={profileImage} />

--- a/frontend/src/features/profile/MyProfile.tsx
+++ b/frontend/src/features/profile/MyProfile.tsx
@@ -274,15 +274,23 @@ const MyProfile = () => {
                 minHeight: "100vh",
                 backgroundRepeat: "no-repeat",
                 backgroundSize: "cover",
-                display: "flex",
                 alignItems: "center",
                 justifyContent: "center"
             }}
         >
             <Grid container
                 direction="column"
+                spacing={3}
             >
-                <h1>[My Profile]</h1>
+                <Grid item
+                    xs={5}
+                    sx={{
+                        fontSize: "3.4rem",
+                        fontWeight: "bold"
+                    }}
+                >
+                    [My Profile]
+                </Grid>
                 <Grid item xs={5}>
                     <ShowAvatar user={user} profileImage={profileImage} />
                 </Grid>

--- a/frontend/src/features/profile/MyProfile.tsx
+++ b/frontend/src/features/profile/MyProfile.tsx
@@ -1,317 +1,338 @@
-import React, { useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 // import { Button } from "@mui/material";
-import axios from "axios";
+import axios from 'axios';
 import Rating from '@mui/material/Rating';
 // import io from "socket.io-client";
-import Grid from "@mui/material/Grid";
-import {Match, User} from "../../types/PrismaType";
-import {fetchProfileUser} from "../../hooks/profile/useProfileUser";
-import useQueryMatches from "../../hooks/match/useWueryMatch";
-import ShowAvatar from "../../components/profile/ShowAvatar";
-import ImageUploadButton from "../../components/profile/ImageUploadButton";
+import Grid from '@mui/material/Grid';
+import { Match, User } from '../../types/PrismaType';
+import { fetchProfileUser } from '../../hooks/profile/useProfileUser';
+import useQueryMatches from '../../hooks/match/useWueryMatch';
+import ShowAvatar from '../../components/profile/ShowAvatar';
+import ImageUploadButton from '../../components/profile/ImageUploadButton';
 // import OtherPeopleProfile from "./OtherPeopleProfile";
-import NotificationButton from "../../components/profile/NotificationButton";
+import NotificationButton from '../../components/profile/NotificationButton';
 
 const MyProfile = () => {
-    const [user, setUser] = useState<User>();
-    // const socket = io("http://localhost:8080");
-    const UserPromises = fetchProfileUser();
-    useEffect(() => {
-        UserPromises.then((userDto: User) => {
-            setUser(userDto);
-        });
-    }, []);
+  const [user, setUser] = useState<User>();
+  // const socket = io("http://localhost:8080");
+  const UserPromises = fetchProfileUser();
+  useEffect(() => {
+    UserPromises.then((userDto: User) => {
+      setUser(userDto);
+    });
+  }, []);
 
-    // const getFriends = async () => {
-    //     const {data} = await axios.get<User[]>(`http://localhost:8080/user/friend`);
-    //     return data;
-    // }
+  // const getFriends = async () => {
+  //     const {data} = await axios.get<User[]>(`http://localhost:8080/user/friend`);
+  //     return data;
+  // }
 
-    // const [friends, setFriends] = useState<User[]>([]);
+  // const [friends, setFriends] = useState<User[]>([]);
 
-    // const HandleFriendListButton = () => {
-    //     const friendsPromise = getFriends();
-    //     friendsPromise.then((data) => {
-    //         console.log('data => ', data[0]);
-    //         setFriends(data);
-    //     });
-    //     console.log(friends[0]);
-    // };
+  // const HandleFriendListButton = () => {
+  //     const friendsPromise = getFriends();
+  //     friendsPromise.then((data) => {
+  //         console.log('data => ', data[0]);
+  //         setFriends(data);
+  //     });
+  //     console.log(friends[0]);
+  // };
 
-    const [matchArr, setMatches] = useState<Match[]>([]);
-    // const [winnerId] = useState<string>('');
-    const MatchPromises = useQueryMatches();
-    useEffect(() => {
-        MatchPromises.then((matches: Match[]) => {
-            setMatches(matches);
-            // setWinnerId(matches[matches.length - 1].winner_id);
-        });
-    }, []);
+  const [matchArr, setMatches] = useState<Match[]>([]);
+  // const [winnerId] = useState<string>('');
+  const MatchPromises = useQueryMatches();
+  useEffect(() => {
+    MatchPromises.then((matches: Match[]) => {
+      setMatches(matches);
+      // setWinnerId(matches[matches.length - 1].winner_id);
+    });
+  }, []);
 
-    // function ShowResult(props: { p1: string, p2: string }) {
-    //     // console.log('winnerId', winnerId);
-    //     if (winnerId === '1') {
-    //         return (
-    //             <h2>
-    //                 <div>
-    //                     Winner
-    //                     &nbsp;=&gt;
-    //                     {props.p1}!!!
-    //                 </div>
-    //             </h2>
-    //         );
-    //     }
-    //     return (
-    //         <h2>
-    //             <div>
-    //                 Winner
-    //                 &nbsp;=&gt;
-    //                 {props.p2}!!!
-    //             </div>
-    //         </h2>
-    //     );
-    // }
+  // function ShowResult(props: { p1: string, p2: string }) {
+  //     // console.log('winnerId', winnerId);
+  //     if (winnerId === '1') {
+  //         return (
+  //             <h2>
+  //                 <div>
+  //                     Winner
+  //                     &nbsp;=&gt;
+  //                     {props.p1}!!!
+  //                 </div>
+  //             </h2>
+  //         );
+  //     }
+  //     return (
+  //         <h2>
+  //             <div>
+  //                 Winner
+  //                 &nbsp;=&gt;
+  //                 {props.p2}!!!
+  //             </div>
+  //         </h2>
+  //     );
+  // }
 
-    interface MatchListProps {
-        matches: Match[];
-    }
+  interface MatchListProps {
+    matches: Match[];
+  }
 
-    function ShowAchievement({matches}: MatchListProps) {
-        const countMyWinTime =  () => {
-            let count: number = 0;
-            for (const match of matches) {
-                const winnerName = match.winner_id === '1' ? match.player1 : match.player2;
-                if (winnerName === user?.name) {
-                    count += 1;
-                }
-            }
-            return count;
+  function ShowAchievement({ matches }: MatchListProps) {
+    const countMyWinTime = () => {
+      let count: number = 0;
+      for (const match of matches) {
+        const winnerName =
+          match.winner_id === '1' ? match.player1 : match.player2;
+        if (winnerName === user?.name) {
+          count += 1;
         }
-        enum Achievement {
-            "Beginner" = 0,
-            "Intermediate" = 5,
-            "Advanced" = 10,
-            "Expert" = 15,
-        }
-
-        const getAchievement = () => {
-            if (countMyWinTime() < Achievement.Intermediate) {
-                return "Beginner";
-            }
-            if (countMyWinTime() < Achievement.Advanced) {
-                return "Intermediate";
-            }
-            if (countMyWinTime() < Achievement.Expert) {
-                return "Advanced";
-            }
-            return "Expert";
-        };
-
-        return (
-            <div
-                style={{
-                    color: '#3C444B'
-                }}
-            >
-                <h2>
-                    Your current achievement : {getAchievement()}
-                <p></p>
-                <Rating
-                    name={user?.name}
-                    defaultValue={countMyWinTime()}
-                    precision={0.5}
-                    max={20}
-                    readOnly
-                />
-                <p></p>
-                </h2>
-            </div>
-        );
-    }
-
-    // function MatchList({ matches }: MatchListProps) {
-    //     const [selectedPlayer, setSelectedPlayer] = useState(user?.name);
-    //     const [filteredMatches, setFilteredMatches] = useState<Match[]>([]);
-    //
-    //     useEffect(() => {
-    //         ユーザー情報を取得する非同期処理
-            // const getUserInfo = async () => {
-            //     const userDto = await fetchProfileUser();
-            //     if (userDto) {
-            //         setSelectedPlayer(userDto.name);
-            //     }
-            // };
-            // getUserInfo();
-        // }, []);
-
-        // useEffect(() => {
-        //     選択されたプレーヤー名が空の場合は全ての試合を表示する
-        //     player1もしくはplayer2に選択されたプレーヤー名を含む試合をフィルタリングする
-            // const filtered = matches.filter((match) => match.player1 === selectedPlayer || match.player2 === selectedPlayer);
-            // setFilteredMatches(filtered);
-        // }, []);
-
-        // return (
-        //     <div
-        //         style={{
-        //             color: '#3C444B'
-        //         }}
-        //     >
-        //         {/* フィルタリングされた試合のみ表示 */}
-        //         <h3>[⇩ Previous Record]</h3>
-        //         {filteredMatches.map((match) => (
-        //             <div key={match.id}>
-        //                 <h3>
-        //                     [{match.id}] {match.player1} vs {match.player2}
-        //                 </h3>
-        //                 <div>
-        //                     <ShowResult p1={match.player1} p2={match.player2}/>
-        //                 </div>
-        //             </div>
-        //         ))}
-        //     </div>
-        // );
-    // }
-
-    // interface FriendProps {
-    //     friendName: string;
-    // }
-
-    // function FriendStatus({friendName}: FriendProps) {
-    //     const [isOnline, setIsOnline] = useState(null);
-    //
-    //     useEffect(() => {
-    //         WebSocketを使用して、友達のオンライン/オフライン状態を取得する
-            // socket.emit("getFriendStatus", friendName);
-            //
-            // サーバーからの応答を受信する
-            // socket.on("friendStatus", (status) => {
-            //     setIsOnline(status);
-            // });
-            //
-            // コンポーネントのアンマウント時にWebSocket接続を解除する
-            // return () => {
-            //     socket.off("friendStatus");
-            // };
-        // }, [friendName]);
-        //
-        // if (isOnline === null) {
-        //     return <span>Loading...</span>;
-        // }
-        // return (
-        //     <span>{isOnline ? " => 🤩" : " => 🫥"}</span>
-        // );
-    // }
-    //
-
-    const uploadImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
-        const { files } = event.target;
-        if (files?.[0]) {
-            const blobFiles = URL.createObjectURL(files[0]);
-            const file = files[0];
-            let base64: string;
-            console.log("THIS ONE: </>", blobFiles);
-            const reader = new FileReader();
-            reader.readAsDataURL(file);
-
-            reader.onload = async () => {
-                base64 = reader.result as string;
-                console.log("base64: ", base64);
-
-                try {
-                    const response = await axios.post(
-                        "http://localhost:8080/user/add/image",
-                        { image: base64 },
-                        { headers: { Authorization: `Bearer ${localStorage.getItem("token")}` } }
-                    );
-                    console.log("THIS ONE: ", response);
-                    setProfileImage(base64);
-                } catch (error) {
-                    console.error(error);
-                    console.log("This file is too large!!!!");
-                }
-            };
-        }
+      }
+      return count;
     };
 
-    const [profileImage, setProfileImage] = useState('');
-    useEffect(() => {
-        const profileUser = fetchProfileUser();
-        profileUser.then((us) => {
-            setProfileImage(us?.image);
-        });
-    }, []);
+    enum Achievement {
+      'Beginner' = 0,
+      'Intermediate' = 5,
+      'Advanced' = 10,
+      'Expert' = 15,
+    }
 
-    // const FriendListButton = () => (
-    //         <div>
-    //             <Button
-    //             variant="outlined"
-    //             color="primary"
-    //             size="large"
-    //             onClick={HandleFriendListButton}
-    //         >
-    //             friend list
-    //         </Button><h3>
-    //             {friends.map((friend: User) => (
-    //                 <div key={friend.id}>
-    //                     [{friend.name}]
-    //                     <FriendStatus friendName={friend.name}/>
-    //                     <OtherPeopleProfile friend={friend} />
-    //                 </div>
-    //             ))}
-    //         </h3>
-    //         </div>
-    //     )
+    const getAchievement = () => {
+      if (countMyWinTime() < Achievement.Intermediate) {
+        return 'Beginner';
+      }
+      if (countMyWinTime() < Achievement.Advanced) {
+        return 'Intermediate';
+      }
+      if (countMyWinTime() < Achievement.Expert) {
+        return 'Advanced';
+      }
+      return 'Expert';
+    };
 
     return (
-        <div
-            style={{
-                backgroundColor: "#EDF0F4",
-                minHeight: "100vh",
-                backgroundRepeat: "no-repeat",
-                backgroundSize: "cover",
-                alignItems: "center",
-                justifyContent: "center"
-            }}
-        >
-            <Grid container
-                direction="column"
-                spacing={3}
-            >
-                <Grid item
-                    xs={5}
-                    sx={{
-                        fontSize: "3.4rem",
-                        fontWeight: "bold"
-                    }}
-                >
-                    [My Profile]
-                </Grid>
-                <Grid item xs={5} sx={{
-                    display: "flex",
-                    alignItems: "flex-end",
-                    justifyContent: "flex-end",
-                }}
-                >
-                    <NotificationButton />
-                </Grid>
-                <Grid item xs={5}>
-                    <ShowAvatar user={user} profileImage={profileImage} />
-                </Grid>
-                <Grid item xs={5}
-                        style={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            color: "#3C444B" }}>
-                    <ImageUploadButton onUpload={uploadImage} />
-                </Grid>
-                <Grid item xs={5} style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B5D3D5", marginTop: "-20px" }}>
-                    <ShowAchievement matches={matchArr} />
-                </Grid>
-            </Grid>
-        </div>
+      <div
+        style={{
+          color: '#3C444B',
+        }}
+      >
+        <h2>
+          Your current achievement : {getAchievement()}
+          <p></p>
+          <Rating
+            name={user?.name}
+            defaultValue={countMyWinTime()}
+            precision={0.5}
+            max={20}
+            readOnly
+          />
+          <p></p>
+        </h2>
+      </div>
     );
-}
+  }
+
+  // function MatchList({ matches }: MatchListProps) {
+  //     const [selectedPlayer, setSelectedPlayer] = useState(user?.name);
+  //     const [filteredMatches, setFilteredMatches] = useState<Match[]>([]);
+  //
+  //     useEffect(() => {
+  //         ユーザー情報を取得する非同期処理
+  // const getUserInfo = async () => {
+  //     const userDto = await fetchProfileUser();
+  //     if (userDto) {
+  //         setSelectedPlayer(userDto.name);
+  //     }
+  // };
+  // getUserInfo();
+  // }, []);
+
+  // useEffect(() => {
+  //     選択されたプレーヤー名が空の場合は全ての試合を表示する
+  //     player1もしくはplayer2に選択されたプレーヤー名を含む試合をフィルタリングする
+  // const filtered = matches.filter((match) => match.player1 === selectedPlayer || match.player2 === selectedPlayer);
+  // setFilteredMatches(filtered);
+  // }, []);
+
+  // return (
+  //     <div
+  //         style={{
+  //             color: '#3C444B'
+  //         }}
+  //     >
+  //         {/* フィルタリングされた試合のみ表示 */}
+  //         <h3>[⇩ Previous Record]</h3>
+  //         {filteredMatches.map((match) => (
+  //             <div key={match.id}>
+  //                 <h3>
+  //                     [{match.id}] {match.player1} vs {match.player2}
+  //                 </h3>
+  //                 <div>
+  //                     <ShowResult p1={match.player1} p2={match.player2}/>
+  //                 </div>
+  //             </div>
+  //         ))}
+  //     </div>
+  // );
+  // }
+
+  // interface FriendProps {
+  //     friendName: string;
+  // }
+
+  // function FriendStatus({friendName}: FriendProps) {
+  //     const [isOnline, setIsOnline] = useState(null);
+  //
+  //     useEffect(() => {
+  //         WebSocketを使用して、友達のオンライン/オフライン状態を取得する
+  // socket.emit("getFriendStatus", friendName);
+  //
+  // サーバーからの応答を受信する
+  // socket.on("friendStatus", (status) => {
+  //     setIsOnline(status);
+  // });
+  //
+  // コンポーネントのアンマウント時にWebSocket接続を解除する
+  // return () => {
+  //     socket.off("friendStatus");
+  // };
+  // }, [friendName]);
+  //
+  // if (isOnline === null) {
+  //     return <span>Loading...</span>;
+  // }
+  // return (
+  //     <span>{isOnline ? " => 🤩" : " => 🫥"}</span>
+  // );
+  // }
+  //
+
+  const uploadImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    if (files?.[0]) {
+      const blobFiles = URL.createObjectURL(files[0]);
+      const file = files[0];
+      let base64: string;
+      console.log('THIS ONE: </>', blobFiles);
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+
+      reader.onload = async () => {
+        base64 = reader.result as string;
+        console.log('base64: ', base64);
+
+        try {
+          const response = await axios.post(
+            'http://localhost:8080/user/add/image',
+            { image: base64 },
+            {
+              headers: {
+                Authorization: `Bearer ${localStorage.getItem('token')}`,
+              },
+            },
+          );
+          console.log('THIS ONE: ', response);
+          setProfileImage(base64);
+        } catch (error) {
+          console.error(error);
+          console.log('This file is too large!!!!');
+        }
+      };
+    }
+  };
+
+  const [profileImage, setProfileImage] = useState('');
+  useEffect(() => {
+    const profileUser = fetchProfileUser();
+    profileUser.then((us) => {
+      setProfileImage(us?.image);
+    });
+  }, []);
+
+  // const FriendListButton = () => (
+  //         <div>
+  //             <Button
+  //             variant="outlined"
+  //             color="primary"
+  //             size="large"
+  //             onClick={HandleFriendListButton}
+  //         >
+  //             friend list
+  //         </Button><h3>
+  //             {friends.map((friend: User) => (
+  //                 <div key={friend.id}>
+  //                     [{friend.name}]
+  //                     <FriendStatus friendName={friend.name}/>
+  //                     <OtherPeopleProfile friend={friend} />
+  //                 </div>
+  //             ))}
+  //         </h3>
+  //         </div>
+  //     )
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#EDF0F4',
+        minHeight: '100vh',
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'cover',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Grid container direction="column" spacing={3}>
+        <Grid
+          item
+          xs={5}
+          sx={{
+            fontSize: '3.4rem',
+            fontWeight: 'bold',
+          }}
+        >
+          [My Profile]
+        </Grid>
+        <Grid
+          item
+          xs={5}
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <NotificationButton />
+        </Grid>
+        <Grid item xs={5}>
+          <ShowAvatar user={user} profileImage={profileImage} />
+        </Grid>
+        <Grid
+          item
+          xs={5}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#3C444B',
+          }}
+        >
+          <ImageUploadButton onUpload={uploadImage} />
+        </Grid>
+        <Grid
+          item
+          xs={5}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#B5D3D5',
+            marginTop: '-20px',
+          }}
+        >
+          <ShowAchievement matches={matchArr} />
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
 
 export default MyProfile;

--- a/frontend/src/features/profile/MyProfile.tsx
+++ b/frontend/src/features/profile/MyProfile.tsx
@@ -1,21 +1,19 @@
 import React, { useEffect, useState} from 'react';
-import { Button } from "@mui/material";
+// import { Button } from "@mui/material";
 import axios from "axios";
 import Rating from '@mui/material/Rating';
-import io from "socket.io-client";
+// import io from "socket.io-client";
 import Grid from "@mui/material/Grid";
 import {Match, User} from "../../types/PrismaType";
 import {fetchProfileUser} from "../../hooks/profile/useProfileUser";
 import useQueryMatches from "../../hooks/match/useWueryMatch";
 import ShowAvatar from "../../components/profile/ShowAvatar";
 import ImageUploadButton from "../../components/profile/ImageUploadButton";
-import FingerPrintButton from "../../components/profile/FingerPrintButton";
-import InputFriendId from "../../components/profile/InputFriendId";
-import OtherPeopleProfile from "./OtherPeopleProfile";
+// import OtherPeopleProfile from "./OtherPeopleProfile";
 
 const MyProfile = () => {
     const [user, setUser] = useState<User>();
-    const socket = io("http://localhost:8080");
+    // const socket = io("http://localhost:8080");
     const UserPromises = fetchProfileUser();
     useEffect(() => {
         UserPromises.then((userDto: User) => {
@@ -23,24 +21,24 @@ const MyProfile = () => {
         });
     }, []);
 
-    const getFriends = async () => {
-        const {data} = await axios.get<User[]>(`http://localhost:8080/user/friend`);
-        return data;
-    }
+    // const getFriends = async () => {
+    //     const {data} = await axios.get<User[]>(`http://localhost:8080/user/friend`);
+    //     return data;
+    // }
 
-    const [friends, setFriends] = useState<User[]>([]);
+    // const [friends, setFriends] = useState<User[]>([]);
 
-    const HandleFriendListButton = () => {
-        const friendsPromise = getFriends();
-        friendsPromise.then((data) => {
-            console.log('data => ', data[0]);
-            setFriends(data);
-        });
-        console.log(friends[0]);
-    };
+    // const HandleFriendListButton = () => {
+    //     const friendsPromise = getFriends();
+    //     friendsPromise.then((data) => {
+    //         console.log('data => ', data[0]);
+    //         setFriends(data);
+    //     });
+    //     console.log(friends[0]);
+    // };
 
     const [matchArr, setMatches] = useState<Match[]>([]);
-    const [winnerId] = useState<string>('');
+    // const [winnerId] = useState<string>('');
     const MatchPromises = useQueryMatches();
     useEffect(() => {
         MatchPromises.then((matches: Match[]) => {
@@ -49,29 +47,29 @@ const MyProfile = () => {
         });
     }, []);
 
-    function ShowResult(props: { p1: string, p2: string }) {
-        // console.log('winnerId', winnerId);
-        if (winnerId === '1') {
-            return (
-                <h2>
-                    <div>
-                        Winner
-                        &nbsp;=&gt;
-                        {props.p1}!!!
-                    </div>
-                </h2>
-            );
-        }
-        return (
-            <h2>
-                <div>
-                    Winner
-                    &nbsp;=&gt;
-                    {props.p2}!!!
-                </div>
-            </h2>
-        );
-    }
+    // function ShowResult(props: { p1: string, p2: string }) {
+    //     // console.log('winnerId', winnerId);
+    //     if (winnerId === '1') {
+    //         return (
+    //             <h2>
+    //                 <div>
+    //                     Winner
+    //                     &nbsp;=&gt;
+    //                     {props.p1}!!!
+    //                 </div>
+    //             </h2>
+    //         );
+    //     }
+    //     return (
+    //         <h2>
+    //             <div>
+    //                 Winner
+    //                 &nbsp;=&gt;
+    //                 {props.p2}!!!
+    //             </div>
+    //         </h2>
+    //     );
+    // }
 
     interface MatchListProps {
         matches: Match[];
@@ -130,80 +128,80 @@ const MyProfile = () => {
         );
     }
 
-    function MatchList({ matches }: MatchListProps) {
-        const [selectedPlayer, setSelectedPlayer] = useState(user?.name);
-        const [filteredMatches, setFilteredMatches] = useState<Match[]>([]);
+    // function MatchList({ matches }: MatchListProps) {
+    //     const [selectedPlayer, setSelectedPlayer] = useState(user?.name);
+    //     const [filteredMatches, setFilteredMatches] = useState<Match[]>([]);
+    //
+    //     useEffect(() => {
+    //         ユーザー情報を取得する非同期処理
+            // const getUserInfo = async () => {
+            //     const userDto = await fetchProfileUser();
+            //     if (userDto) {
+            //         setSelectedPlayer(userDto.name);
+            //     }
+            // };
+            // getUserInfo();
+        // }, []);
 
-        useEffect(() => {
-            // ユーザー情報を取得する非同期処理
-            const getUserInfo = async () => {
-                const userDto = await fetchProfileUser();
-                if (userDto) {
-                    setSelectedPlayer(userDto.name);
-                }
-            };
-            getUserInfo();
-        }, []);
+        // useEffect(() => {
+        //     選択されたプレーヤー名が空の場合は全ての試合を表示する
+        //     player1もしくはplayer2に選択されたプレーヤー名を含む試合をフィルタリングする
+            // const filtered = matches.filter((match) => match.player1 === selectedPlayer || match.player2 === selectedPlayer);
+            // setFilteredMatches(filtered);
+        // }, []);
 
-        useEffect(() => {
-            // 選択されたプレーヤー名が空の場合は全ての試合を表示する
-            // player1もしくはplayer2に選択されたプレーヤー名を含む試合をフィルタリングする
-            const filtered = matches.filter((match) => match.player1 === selectedPlayer || match.player2 === selectedPlayer);
-            setFilteredMatches(filtered);
-        }, []);
+        // return (
+        //     <div
+        //         style={{
+        //             color: '#3C444B'
+        //         }}
+        //     >
+        //         {/* フィルタリングされた試合のみ表示 */}
+        //         <h3>[⇩ Previous Record]</h3>
+        //         {filteredMatches.map((match) => (
+        //             <div key={match.id}>
+        //                 <h3>
+        //                     [{match.id}] {match.player1} vs {match.player2}
+        //                 </h3>
+        //                 <div>
+        //                     <ShowResult p1={match.player1} p2={match.player2}/>
+        //                 </div>
+        //             </div>
+        //         ))}
+        //     </div>
+        // );
+    // }
 
-        return (
-            <div
-                style={{
-                    color: '#3C444B'
-                }}
-            >
-                {/* フィルタリングされた試合のみ表示 */}
-                <h3>[⇩ Previous Record]</h3>
-                {filteredMatches.map((match) => (
-                    <div key={match.id}>
-                        <h3>
-                            [{match.id}] {match.player1} vs {match.player2}
-                        </h3>
-                        <div>
-                            <ShowResult p1={match.player1} p2={match.player2}/>
-                        </div>
-                    </div>
-                ))}
-            </div>
-        );
-    }
+    // interface FriendProps {
+    //     friendName: string;
+    // }
 
-    interface FriendProps {
-        friendName: string;
-    }
-
-    function FriendStatus({friendName}: FriendProps) {
-        const [isOnline, setIsOnline] = useState(null);
-
-        useEffect(() => {
-            // WebSocketを使用して、友達のオンライン/オフライン状態を取得する
-            socket.emit("getFriendStatus", friendName);
-
+    // function FriendStatus({friendName}: FriendProps) {
+    //     const [isOnline, setIsOnline] = useState(null);
+    //
+    //     useEffect(() => {
+    //         WebSocketを使用して、友達のオンライン/オフライン状態を取得する
+            // socket.emit("getFriendStatus", friendName);
+            //
             // サーバーからの応答を受信する
-            socket.on("friendStatus", (status) => {
-                setIsOnline(status);
-            });
-
+            // socket.on("friendStatus", (status) => {
+            //     setIsOnline(status);
+            // });
+            //
             // コンポーネントのアンマウント時にWebSocket接続を解除する
-            return () => {
-                socket.off("friendStatus");
-            };
-        }, [friendName]);
-
-        if (isOnline === null) {
-            return <span>Loading...</span>;
-        }
-        return (
-            <span>{isOnline ? " => 🤩" : " => 🫥"}</span>
-        );
-    }
-
+            // return () => {
+            //     socket.off("friendStatus");
+            // };
+        // }, [friendName]);
+        //
+        // if (isOnline === null) {
+        //     return <span>Loading...</span>;
+        // }
+        // return (
+        //     <span>{isOnline ? " => 🤩" : " => 🫥"}</span>
+        // );
+    // }
+    //
     // const steveJobsImage = "https://cdn.profoto.com/cdn/053149e/contentassets/d39349344d004f9b8963df1551f24bf4/profoto-albert-watson-steve-jobs-pinned-image-original.jpg?width=1280&quality=75&format=jpg";
 
     const uploadImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -244,32 +242,31 @@ const MyProfile = () => {
         });
     }, []);
 
-    const handleFingerPrintButton = () => {
-        navigator.clipboard.writeText(user?.id as string);
-    }
+    // const handleFingerPrintButton = () => {
+    //     navigator.clipboard.writeText(user?.id as string);
+    // }
+    //
+    // const FriendListButton = () => (
+    //         <div>
+    //             <Button
+    //             variant="outlined"
+    //             color="primary"
+    //             size="large"
+    //             onClick={HandleFriendListButton}
+    //         >
+    //             friend list
+    //         </Button><h3>
+    //             {friends.map((friend: User) => (
+    //                 <div key={friend.id}>
+    //                     [{friend.name}]
+    //                     <FriendStatus friendName={friend.name}/>
+    //                     <OtherPeopleProfile friend={friend} />
+    //                 </div>
+    //             ))}
+    //         </h3>
+    //         </div>
+    //     )
 
-    const FriendListButton = () => (
-            <div>
-                <Button
-                variant="outlined"
-                color="primary"
-                size="large"
-                onClick={HandleFriendListButton}
-            >
-                friend list
-            </Button><h3>
-                {friends.map((friend: User) => (
-                    <div key={friend.id}>
-                        [{friend.name}]
-                        <FriendStatus friendName={friend.name}/>
-                        <OtherPeopleProfile friend={friend} />
-                    </div>
-                ))}
-            </h3>
-            </div>
-        )
-
-    // @ts-ignore
     return (
         <div
             style={{
@@ -282,47 +279,27 @@ const MyProfile = () => {
                 justifyContent: "center"
             }}
         >
-            <h2>
-                <Grid container
-                    direction="column"
-                >
+            <Grid container
+                direction="column"
+            >
                 <h1>[My Profile]</h1>
-                    <Grid item xs={5}>
-                        <ShowAvatar user={user} profileImage={profileImage} />
-                    </Grid>
-                    <Grid item xs={5}
-                            style={{
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                color: "#3C444B" }}>
-                        <ImageUploadButton onUpload={uploadImage} />
-                    </Grid>
-                    <Grid item xs={5}>
-                        <h1 style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B2B9C5", marginTop: "-20px" }}>
-                            Find your friend!
-                        </h1>
-                    </Grid>
-                    <Grid item xs={10} style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B5D3D5", marginTop: "-20px" }} marginTop={-10}>
-                        <InputFriendId props={user} />
-                    </Grid>
-                    <Grid item xs={10} style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B5D3D5", marginTop: "20px" }}>
-                        <FingerPrintButton onClick={handleFingerPrintButton} />
-                    </Grid>
-                        <Grid item xs={5} style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B5D3D5", marginTop: "-20px" }} justifyContent={"center"} marginTop={3}>
-                            <FriendListButton />
-                        </Grid>
-                        <Grid item xs={5} style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B5D3D5", marginTop: "-20px" }}>
-                            <MatchList matches={matchArr} />
-                        </Grid>
-                        <Grid item xs={5} style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B5D3D5", marginTop: "-20px" }}>
-                            <ShowAchievement matches={matchArr} />
-                        </Grid>
-                    </Grid>
-            </h2>
+                <Grid item xs={5}>
+                    <ShowAvatar user={user} profileImage={profileImage} />
+                </Grid>
+                <Grid item xs={5}
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            color: "#3C444B" }}>
+                    <ImageUploadButton onUpload={uploadImage} />
+                </Grid>
+                <Grid item xs={5} style={{ display: "flex", alignItems: "center", justifyContent: "center", color: "#B5D3D5", marginTop: "-20px" }}>
+                    <ShowAchievement matches={matchArr} />
+                </Grid>
+            </Grid>
         </div>
     );
 }
-
 
 export default MyProfile;

--- a/frontend/src/features/profile/OtherPeopleProfile.tsx
+++ b/frontend/src/features/profile/OtherPeopleProfile.tsx
@@ -45,7 +45,7 @@ const OtherPeopleProfile = (props: OtherPeopleProfileProps) => (
                         justifyContent: "center"
                     }}
                 >
-                    <FriendRequestButton />
+                    <FriendRequestButton user={props.friend}/>
                 </Grid>
                 <Grid
                 item xs={5}

--- a/frontend/src/features/profile/OtherPeopleProfile.tsx
+++ b/frontend/src/features/profile/OtherPeopleProfile.tsx
@@ -5,11 +5,11 @@ import ShowAvatar from "../../components/profile/ShowAvatar";
 import FriendRequestButton from "../../components/profile/FriendRequestButton";
 import FriendListButton from "../../components/profile/FriendListButton";
 
-interface FriendProfileProps {
+interface OtherPeopleProfileProps {
     friend: User | undefined;
 }
 
-const FriendProfile = (props: FriendProfileProps) => (
+const OtherPeopleProfile = (props: OtherPeopleProfileProps) => (
         <div
             style={{
                 backgroundColor: "#EDF0F4",
@@ -61,4 +61,4 @@ const FriendProfile = (props: FriendProfileProps) => (
         </div>
     )
 
-export default FriendProfile;
+export default OtherPeopleProfile;

--- a/frontend/src/features/profile/OtherPeopleProfile.tsx
+++ b/frontend/src/features/profile/OtherPeopleProfile.tsx
@@ -1,64 +1,63 @@
 import React from 'react';
-import {Grid} from "@mui/material"
-import {User} from "../../types/PrismaType";
-import ShowAvatar from "../../components/profile/ShowAvatar";
-import FriendRequestButton from "../../components/profile/FriendRequestButton";
-import FriendListButton from "../../components/profile/FriendListButton";
+import { Grid } from '@mui/material';
+import { User } from '../../types/PrismaType';
+import ShowAvatar from '../../components/profile/ShowAvatar';
+import FriendRequestButton from '../../components/profile/FriendRequestButton';
+import FriendListButton from '../../components/profile/FriendListButton';
 
 interface OtherPeopleProfileProps {
-    friend: User | undefined;
+  friend: User | undefined;
 }
 
 const OtherPeopleProfile = (props: OtherPeopleProfileProps) => (
-        <div
-            style={{
-                backgroundColor: "#EDF0F4",
-                minHeight: "100vh",
-                backgroundRepeat: "no-repeat",
-                backgroundSize: "cover",
-                alignItems: "center",
-                justifyContent: "center"
-            }}
-        >
-            <Grid
-                container
-                direction="column"
-                spacing={3}
-            >
-                <Grid
-                    item xs={5}
-                    sx={{
-                        fontSize: "4rem",
-                        fontWeight: "bold"
-                    }}
-                >
-                    [{props.friend?.name} Profile]
-                </Grid>
-                <Grid item xs={5}>
-                    <ShowAvatar user={props.friend} profileImage={props.friend?.image} />
-                </Grid>
-                <Grid
-                    item xs={5}
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center"
-                    }}
-                >
-                    <FriendRequestButton user={props.friend}/>
-                </Grid>
-                <Grid
-                    item xs={5}
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center"
-                    }}
-                >
-                    <FriendListButton user={props.friend}/>
-                </Grid>
-            </Grid>
-        </div>
-    )
+  <div
+    style={{
+      backgroundColor: '#EDF0F4',
+      minHeight: '100vh',
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+      alignItems: 'center',
+      justifyContent: 'center',
+    }}
+  >
+    <Grid container direction="column" spacing={3}>
+      <Grid
+        item
+        xs={5}
+        sx={{
+          fontSize: '4rem',
+          fontWeight: 'bold',
+        }}
+      >
+        [{props.friend?.name} Profile]
+      </Grid>
+      <Grid item xs={5}>
+        <ShowAvatar user={props.friend} profileImage={props.friend?.image} />
+      </Grid>
+      <Grid
+        item
+        xs={5}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <FriendRequestButton user={props.friend} />
+      </Grid>
+      <Grid
+        item
+        xs={5}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <FriendListButton user={props.friend} />
+      </Grid>
+    </Grid>
+  </div>
+);
 
 export default OtherPeopleProfile;

--- a/frontend/src/features/profile/Profile.tsx
+++ b/frontend/src/features/profile/Profile.tsx
@@ -286,6 +286,7 @@ const Profile = () => {
                 <Grid container
                     direction="column"
                 >
+                <h1>[My Profile]</h1>
                     <Grid item xs={5}>
                         <ShowAvatar user={user} profileImage={profileImage} />
                     </Grid>

--- a/frontend/src/features/profile/ProfileRouting.tsx
+++ b/frontend/src/features/profile/ProfileRouting.tsx
@@ -4,58 +4,61 @@ import { useParams } from 'react-router-dom';
 import { User } from '../../types/PrismaType';
 import MyProfile from './MyProfile';
 import OtherPeopleProfile from './OtherPeopleProfile';
-import {fetchProfileUser} from "../../hooks/profile/useProfileUser";
+import { fetchProfileUser } from '../../hooks/profile/useProfileUser';
 
 const ProfileRouting = () => {
-    const { name } = useParams();
-    const [loginUser, setLoginUser] = useState<User>();
-    const [nonLoginUser, setNonLoginUser] = useState<User>();
+  const { name } = useParams();
+  const [loginUser, setLoginUser] = useState<User>();
+  const [nonLoginUser, setNonLoginUser] = useState<User>();
 
-    /* 自分が誰なのかという情報 */
-    useEffect(() => {
-        const UserPromises = fetchProfileUser();
-        UserPromises.then((userDto: User) => {
-            setLoginUser(userDto);
-        });
-    }, []);
+  /* 自分が誰なのかという情報 */
+  useEffect(() => {
+    const UserPromises = fetchProfileUser();
+    UserPromises.then((userDto: User) => {
+      setLoginUser(userDto);
+    });
+  }, []);
 
-    /* nonLogin userの情報 */
-    useEffect(() => {
-        const fetchNonLoginUser = async (nm: string | undefined) => {
-            const { data } = await axios.get<User>(`http://localhost:8080/user/name`,{
-                params: {
-                    name: nm,
-                }
-            })
-            setNonLoginUser(data);
-        };
-        if (name) {
-            console.log('name', name);
-            fetchNonLoginUser(name);
-        }
-    },  []);
-
-    useEffect(() => {
-        console.log('nonLoginUser', nonLoginUser);
-    }, [nonLoginUser]);
-
-    const renderProfileStatus = () => {
-        /* login userがparamのnameと一致した時にはProfile Componentを表示する */
-        if (loginUser?.name === name) {
-            return <MyProfile />
-        }
-        if (loginUser?.name !== name && nonLoginUser?.name === name) {
-        /* login userがparamのnameと一致しなかった時にはFriend Profile Componentにuserのpropsを渡して表示する */
-            return <OtherPeopleProfile friend={nonLoginUser}/>;
-        }
-        return <h1>THE NAME PERSON IS NOT EXIST</h1>;
+  /* nonLogin userの情報 */
+  useEffect(() => {
+    const fetchNonLoginUser = async (nm: string | undefined) => {
+      const { data } = await axios.get<User>(
+        `http://localhost:8080/user/name`,
+        {
+          params: {
+            name: nm,
+          },
+        },
+      );
+      setNonLoginUser(data);
     };
+    if (name) {
+      console.log('name', name);
+      fetchNonLoginUser(name);
+    }
+  }, []);
 
-    return (
-        <div>
-            <>{renderProfileStatus()}</>
-        </div>
-    );
+  useEffect(() => {
+    console.log('nonLoginUser', nonLoginUser);
+  }, [nonLoginUser]);
+
+  const renderProfileStatus = () => {
+    /* login userがparamのnameと一致した時にはProfile Componentを表示する */
+    if (loginUser?.name === name) {
+      return <MyProfile />;
+    }
+    if (loginUser?.name !== name && nonLoginUser?.name === name) {
+      /* login userがparamのnameと一致しなかった時にはFriend Profile Componentにuserのpropsを渡して表示する */
+      return <OtherPeopleProfile friend={nonLoginUser} />;
+    }
+    return <h1>THE NAME PERSON IS NOT EXIST</h1>;
+  };
+
+  return (
+    <div>
+      <>{renderProfileStatus()}</>
+    </div>
+  );
 };
 
 export default ProfileRouting;

--- a/frontend/src/features/profile/ProfileRouting.tsx
+++ b/frontend/src/features/profile/ProfileRouting.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useParams } from 'react-router-dom';
 import { User } from '../../types/PrismaType';
-import Profile from './Profile';
-import FriendProfile from './FriendProfile';
+import MyProfile from './MyProfile';
+import OtherPeopleProfile from './OtherPeopleProfile';
 import {fetchProfileUser} from "../../hooks/profile/useProfileUser";
 
 const ProfileRouting = () => {
@@ -42,11 +42,11 @@ const ProfileRouting = () => {
     const renderProfileStatus = () => {
         /* login userがparamのnameと一致した時にはProfile Componentを表示する */
         if (loginUser?.name === name) {
-            return <Profile />
+            return <MyProfile />
         }
         if (loginUser?.name !== name && nonLoginUser?.name === name) {
         /* login userがparamのnameと一致しなかった時にはFriend Profile Componentにuserのpropsを渡して表示する */
-            return <FriendProfile friend={nonLoginUser}/>;
+            return <OtherPeopleProfile friend={nonLoginUser}/>;
         }
         return <h1>THE NAME PERSON IS NOT EXIST</h1>;
     };


### PR DESCRIPTION
## やったこと
自分以外のprofileに行って、followできるようにした
↓
そのfollowに対応する通知を自分のprofileに表示して、acceptとdeclineを候補に挙げた上でできるようにした。
acceptをしたuserフレンド関係になるし、declineしたuserはフレンド関係にならない仕様になっています。
(friend申請も消してるはずだから、notificationの数からも無くなる)

- 次やるべきこと(新たなissue)があれば記載
BLOCK関連の実装 or base64関連

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？
適当なuserを二人用意してください。
AとBというuserを作った場合、Aでloginしているブラウザで、Bのprofile画面に行ってください、そこでfollow buttonを押すと、BでログインしたブラウザのBの画面に通知が来ていると思います。
その通知ボタンを押すと、誰からfriend requestが来ているか確認できて、accept or declineできるので、
1回目はdeclineしてください。そうすると通知が消えていることがわかると思います。(prismaでフレンドになっていないことも確認するといい)
また上と同じ手順でもう一度Bに通知が来るようにしてください。次にacceptしてください。その時にはprismaで確認するとフレンド関係になっていることが確認できると思います。
上記複数クライアントでも対応しているため、余裕があったら確認よろしくお願いします。

## その他
UIに関して意見があったらお願いします(現状のもので個人的にはいいんじゃないかと思っています)

## issues

about : #227 

see also : #227 

close #227 
