### PR TITLE
UTF-8に適していない場合例外をThrowする仕様に変更

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ChatModule } from './chat/chat.module';
@@ -11,6 +11,7 @@ import { GameModule } from './game/game.module';
 import { AppGateway } from './app.gateway';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { UTF8Middleware } from './midlleware/utf-8.middleware';
 
 @Module({
   imports: [
@@ -26,4 +27,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
   controllers: [AppController],
   providers: [AppService, PrismaService, AppGateway, ConfigService, JwtService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(UTF8Middleware).forRoutes('*');
+  }
+}

--- a/backend/src/midlleware/utf-8.middleware.ts
+++ b/backend/src/midlleware/utf-8.middleware.ts
@@ -1,0 +1,30 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class UTF8Middleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const contentType = req.headers['content-type'];
+    if (contentType === 'application/json') {
+      try {
+        const body: Record<string, string> = req.body;
+        for (const prop in body) {
+          if (Object.prototype.hasOwnProperty.call(body, prop)) {
+            const isUtf8 =
+              /^[\u0020-\uD7FF\u0009\u000A\u000D\uE000-\uFFFD]*$/.test(
+                body[prop],
+              );
+            if (!isUtf8) {
+              throw new Error(`Invalid UTF-8 code found in property '${prop}'`);
+            }
+          }
+        }
+        next();
+      } catch (err) {
+        res.status(400).json({ message: err.message });
+      }
+    } else {
+      next();
+    }
+  }
+}


### PR DESCRIPTION
## やったこと
- UTF-8に適していないbodyプロパティがある場合は例外をThrowする

## 動作確認
```
signupを何回かして、仮にUTF-8に適していない場合に例外がスローされるか
```

## その他
- 自分の環境だと画像のエラーがでないため。他の環境では出るかもしれないので出たら報告してください

## issues

about : #263 
close #263 
