### PR TITLE
【JWT】jwtのエラー解消、オンラインステータスの保持部分のリファクタ

### DIFF
--- a/backend/src/app.gateway.ts
+++ b/backend/src/app.gateway.ts
@@ -39,7 +39,6 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   async handleConnection(client: Socket, ...args: any[]) {
     this.logger.log(`[App] Client connected ${client.id}`);
-    console.log('connect');
     const cookie = client.handshake.headers.cookie;
     if (cookie === undefined) return;
     const accessToken = cookie.split('=')[1];
@@ -68,12 +67,9 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   @SubscribeMessage('online_status_check')
   async onlineStatusCheck(@ConnectedSocket() client: Socket) {
-    console.log('==================online_status_check==================');
     const cookie = client.handshake.headers.cookie; //接続タイミングのcookieが保持されるためうまくオンラインステータスの設定ができていない
-    console.log('cookie', cookie);
     if (cookie === undefined) throw new WsException('unAuthorized');
     const accessToken = cookie.split('=')[1];
-    console.log('accessToken: ', accessToken);
     if (accessToken === '') throw new WsException('unAuthorized');
     const { sub: userId } = await this.jwtService.verify(accessToken, {
       secret: this.configService.get('JWT_SECRET'),
@@ -88,18 +84,13 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
     client.data.userId = userId;
     this.userIdToStatus.set(userId, Status.ONLINE);
     this.logger.log(`[App] ${userId} is online (socket id: ${client.id}))`);
-    console.log(this.userIdToStatus);
-    console.log('================================================');
   }
 
   @SubscribeMessage('online_status_delete')
   async onlineStatusDelete(@ConnectedSocket() client: Socket) {
-    console.log('==================online_status_delete==================');
     const cookie = client.handshake.headers.cookie;
-    console.log('cookie', cookie);
     if (cookie === undefined) return;
     const accessToken = cookie.split('=')[1];
-    console.log('accessToken: ', accessToken);
     if (accessToken === '') throw new WsException('unAuthorized');
     const { sub: userId } = await this.jwtService.verify(accessToken, {
       secret: this.configService.get('JWT_SECRET'),
@@ -111,8 +102,6 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
     });
     if (user === null) throw new WsException('unAuthorized');
     await this.userIdToStatus.delete(userId);
-    console.log(this.userIdToStatus);
-    console.log('================================================');
   }
 
   @SubscribeMessage('in_game_status_check')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -14,7 +14,6 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { User } from '@prisma/client';
 import { Response } from 'express';
 import { PrismaUser } from 'src/swagger/type';
 import { UserService } from 'src/user/user.service';
@@ -67,12 +66,14 @@ export class AuthController {
   })
   async login(@Body() dto: AuthDto, @Res({ passthrough: true }) res: Response) {
     const jwt = await this.authService.login(dto);
+
     res.cookie('access_token', jwt.accessToken, {
       httpOnly: true,
       secure: false,
       sameSite: 'lax',
       path: '/',
     });
+
     return;
   }
 
@@ -107,7 +108,7 @@ export class AuthController {
     summary: 'logout user',
   })
   async logout(@Res({ passthrough: true }) res: Response): Promise<Msg> {
-    res.cookie('access_token', '', {
+    res.clearCookie('access_token', {
       httpOnly: true,
       secure: false,
       sameSite: 'lax',

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -27,7 +27,6 @@ import {
   SignUpUserDto,
 } from './dto/auth.dto';
 import { Jwt2FaGuard } from './guards/jwt-2fa.guard';
-import { APP_FILTER } from '@nestjs/core';
 
 @ApiTags('auth')
 @Controller('auth')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -108,7 +108,7 @@ export class AuthController {
     summary: 'logout user',
   })
   async logout(@Res({ passthrough: true }) res: Response): Promise<Msg> {
-    res.clearCookie('access_token', {
+    res.cookie('access_token', '', {
       httpOnly: true,
       secure: false,
       sameSite: 'lax',

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -19,7 +19,6 @@ async function bootstrap() {
   app.enableCors({
     credentials: true,
     origin: ['http://localhost:3000'], //許可したいfrontsideのURL
-    methods: ['POST', 'PATCH'],
   });
   app.use(cookieParser());
   app.use(bodyParser.json({ limit: '20mb' })); // jsonをパースする際のlimitを設定

--- a/backend/src/pong/pong.module.ts
+++ b/backend/src/pong/pong.module.ts
@@ -5,6 +5,6 @@ import { PongController } from './pong.controller';
 
 @Module({
   providers: [PongGateway, PongService],
-  controllers: [PongController]
+  controllers: [PongController],
 })
 export class PongModule {}

--- a/frontend/src/components/auth/FtLoginButtonComponent.tsx
+++ b/frontend/src/components/auth/FtLoginButtonComponent.tsx
@@ -1,6 +1,8 @@
 import { LoadingButton } from '@mui/lab';
 import { styled } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
+import { Socket } from 'socket.io-client';
+import { RootWebsocketContext } from '../../contexts/WebsocketContext';
 
 const ftLoginURL = "http://localhost:8080/auth/login/42"
 
@@ -17,8 +19,18 @@ const CustomButton = styled(LoadingButton)({
 
 function FtLoginButtonComponent() {
   const [Loading, setLoading] = useState(false);
+  const rootSocket: Socket = useContext(RootWebsocketContext);
 
   const handleOnClick = () => { setLoading(true) }
+
+  useEffect(() => {
+
+    if (Loading) {
+      rootSocket.connect();
+    } else {
+      rootSocket.disconnect();
+    }
+  }, [Loading])
 
   return (
     <CustomButton

--- a/frontend/src/components/auth/LoginComponent.tsx
+++ b/frontend/src/components/auth/LoginComponent.tsx
@@ -27,12 +27,14 @@ function LoginComponent() {
   const onSubmit: SubmitHandler<LoginData> = async (data) => {
     let isLogin: Boolean = false;
     try {
+      rootSocket.disconnect();
       await axios.post('http://localhost:8080/auth/login', {
         email: data.email,
         password: data.password,
       });
       reset();
       isLogin = true;
+      rootSocket.connect();
     } catch (error: any) {
       if (error.response) {
         const { message } = error.response.data;
@@ -42,7 +44,6 @@ function LoginComponent() {
     } finally {
       if (isLogin) {
         router('/user');
-        rootSocket.emit('online_status_check');
       }
     }
   }


### PR DESCRIPTION
## やったこと
- jwtのエラーの解消
- オンラインステータスの保持のロジックのリファクタリング
- フレンドのオンラインステータス取得イベントの追加

## 動作確認
```
通常ログインもしくは42Loginをしたときにbackend側のログにオンラインになった旨が表示されるか
```

## その他
- 確かではないですが、accessTokenが期限切れなのにセットされたままの場合はjwtエラーが出ますがサービスとして挙動には問題ないと思います。

## issues

about : #264 

close #264 
