### PR TITLE
リフレッシュトークンを導入

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,8 @@ model User {
   password           String
   twoFactorSecret    String?
   isTwoFactorEnabled Boolean             @default(false)
+  hashedRefreshToken String?
+  // OneTimePassword OneTimePassword?
   image              String
   isFtLogin          Boolean             @default(false)
   Ftlogined         Boolean?

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,7 +16,6 @@ model User {
   twoFactorSecret    String?
   isTwoFactorEnabled Boolean             @default(false)
   hashedRefreshToken String?
-  // OneTimePassword OneTimePassword?
   image              String
   isFtLogin          Boolean             @default(false)
   Ftlogined         Boolean?

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -144,7 +144,6 @@ export class AuthController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ): Promise<Msg> {
-    console.log(`user: ${JSON.stringify(req.user, null, 2)}`);
     await this.authService.logout(req.user.id);
     res.cookie('access_token', '', {
       httpOnly: true,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { FtStrategy } from './strategy/ft.strategy';
 import { Jwt2FaStrategy } from './strategy/jwt-2fa.strategy';
 import { UserModule } from 'src/user/user.module';
 import { UserService } from 'src/user/user.service';
+import { JwtRefreshStrategy } from './strategy/jwt-refresh.strategy';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { UserService } from 'src/user/user.service';
     JwtStrategy,
     FtStrategy,
     Jwt2FaStrategy,
+    JwtRefreshStrategy,
     UserService,
   ],
 })

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -169,7 +169,7 @@ export class AuthService {
     };
     const secret = this.config.get('JWT_SECRET');
     const accessToken = await this.jwt.signAsync(payload, {
-      expiresIn: '10s',
+      expiresIn: '30m',
       secret: secret,
     });
 

--- a/backend/src/auth/strategy/jwt-refresh.strategy.ts
+++ b/backend/src/auth/strategy/jwt-refresh.strategy.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-refresh',
+) {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req) => {
+          let jwt = null;
+          if (req && req.cookies) {
+            jwt = req.cookies['refresh_token'];
+          }
+          return jwt;
+        },
+      ]),
+      ignoreExpiration: false,
+      secretOrKey: config.get('JWT_REFRESH_SECRET'),
+    });
+  }
+
+  async validate(payload: { sub: string; name: string }) {
+    const user = await this.prisma.user.findUnique({
+      where: {
+        id: payload.sub,
+      },
+    });
+    return user;
+  }
+}

--- a/backend/src/auth/type/auth.type.ts
+++ b/backend/src/auth/type/auth.type.ts
@@ -1,3 +1,4 @@
 export type Jwt = {
   accessToken: string;
+  refreshToken: string;
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,22 @@ function App() {
   axios.defaults.withCredentials = true;
   const rootSocket = useSocket('http://localhost:8080/');
 
+  const refreshClient = axios.create();
+
+  axios.interceptors.response.use(
+    (response) => response,
+    async (error:any) => {
+
+      if (error.response.status === 401) {
+        const res = refreshClient.get('http://localhost:8080/auth/refresh').catch((err) => {
+          window.location.href = 'http://localhost:3000/login';
+        })
+        return res
+      }
+      return Promise.reject(error);
+    }
+  )
+
   return (
       <RootWebsocketProvider value={rootSocket}>
       <Grid container>
@@ -83,4 +99,5 @@ function App() {
       </RootWebsocketProvider>
   )
 }
+
 export default App;


### PR DESCRIPTION
## やったこと
JWTリフレッシュトークンを導入した。
アクセストークン(有効時間30m)が切れた後、リフレッシュトークンを使ってアクセストークンを再発行することでユーザーが再ログインする手間を省く。

## やらないこと

- #290 

## 動作確認
`backend/src/auth/auth.service.ts`
```ts
171    const accessToken = await this.jwt.signAsync(payload, {
             expiresIn: '30m', 
             secret: secret,
         });
```
`expiresIn: '30m'` -> `expiresIn: '10s',`に変更してアプリを操作してみて下さい！
10秒経過後、`http://localhost:8080/auth/refresh`にアクセスしていたらOK！
  

https://user-images.githubusercontent.com/60804160/234877801-9e8cc66e-b1bb-4de9-b6f0-b55cbde4f210.mov


## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #254

close #254 
